### PR TITLE
feat!: change customFilter signature & add extra options/methods

### DIFF
--- a/demo/src/app-routing.ts
+++ b/demo/src/app-routing.ts
@@ -12,6 +12,7 @@ import Example10 from './examples/example10';
 import Example11 from './examples/example11';
 import Example12 from './examples/example12';
 import Example13 from './examples/example13';
+import Example14 from './examples/example14';
 import Options01 from './options/options01';
 import Options02 from './options/options02';
 import Options03 from './options/options03';
@@ -44,6 +45,7 @@ import Options29 from './options/options29';
 import Options30 from './options/options30';
 import Options31 from './options/options31';
 import Options32 from './options/options32';
+import Options33 from './options/options33';
 import Methods01 from './methods/methods01';
 import Methods02 from './methods/methods02';
 import Methods03 from './methods/methods03';
@@ -55,6 +57,7 @@ import Methods08 from './methods/methods08';
 import Methods09 from './methods/methods09';
 import Methods10 from './methods/methods10';
 import Methods11 from './methods/methods11';
+import Methods12 from './methods/methods12';
 import Events from './events/events';
 import I18n from './i18n/i18n';
 
@@ -80,6 +83,7 @@ export const exampleRouting = [
       { name: 'example11', view: '/src/examples/example11.html', viewModel: Example11, title: 'The Themes' },
       { name: 'example12', view: '/src/examples/example12.html', viewModel: Example12, title: 'Checkbox/Radio Icons' },
       { name: 'example13', view: '/src/examples/example13.html', viewModel: Example13, title: 'Dynamically Create Select' },
+      { name: 'example14', view: '/src/examples/example14.html', viewModel: Example14, title: 'The Divider' },
     ],
   },
   {
@@ -117,6 +121,7 @@ export const exampleRouting = [
       { name: 'options30', view: '/src/options/options30.html', viewModel: Options30, title: 'Auto-Adjust Drop Height/Width' },
       { name: 'options31', view: '/src/options/options31.html', viewModel: Options31, title: 'Use Select Option as Label' },
       { name: 'options32', view: '/src/options/options32.html', viewModel: Options32, title: 'Sanitizer' },
+      { name: 'options33', view: '/src/options/options33.html', viewModel: Options33, title: 'Classes' },
     ],
   },
   {
@@ -133,6 +138,7 @@ export const exampleRouting = [
       { name: 'methods09', view: '/src/methods/methods09.html', viewModel: Methods09, title: 'The focus/blur' },
       { name: 'methods10', view: '/src/methods/methods10.html', viewModel: Methods10, title: 'The refresh' },
       { name: 'methods11', view: '/src/methods/methods11.html', viewModel: Methods11, title: 'The destroy' },
+      { name: 'methods12', view: '/src/methods/methods12.html', viewModel: Methods12, title: 'The getData' },
     ],
   },
   {

--- a/demo/src/examples/example11.html
+++ b/demo/src/examples/example11.html
@@ -23,7 +23,7 @@
 
 <div>
   <div class="mb-3 row">
-    <label class="col-sm-2 col-form-label col-form-label-sm"> Select </label>
+    <label class="col-sm-2 col-form-label col-form-label-sm">Select</label>
 
     <div class="col-sm-10">
       <select multiple="multiple" class="form-control form-control-sm" data-test="select1" placeholder="form-control-sm">
@@ -44,7 +44,7 @@
   </div>
 
   <div class="mb-3 row">
-    <label class="col-sm-2 col-form-label"> Select </label>
+    <label class="col-sm-2 col-form-label">Select</label>
 
     <div class="col-sm-10">
       <select multiple="multiple" class="form-control" data-test="select2" placeholder="form-control">
@@ -65,7 +65,7 @@
   </div>
 
   <div class="mb-3 row">
-    <label class="col-sm-2 col-form-label col-form-label-lg"> Select </label>
+    <label class="col-sm-2 col-form-label col-form-label-lg">Select</label>
 
     <div class="col-sm-10">
       <select multiple="multiple" class="form-control form-control-lg" data-test="select3" placeholder="form-control-lg">
@@ -81,6 +81,54 @@
         <option value="10">October</option>
         <option value="11">November</option>
         <option value="12">December</option>
+      </select>
+    </div>
+  </div>
+
+  <div class="mb-3 row">
+    <label class="col-sm-2 col-form-label">Dropdown Select</label>
+
+    <div class="col-sm-10">
+      <select class="form-control ms-dropdown" data-test="select4">
+        <optgroup label="Group 1">
+          <option value="1">Option 1</option>
+          <option value="2">Option 2</option>
+          <option value="3">Option 3</option>
+        </optgroup>
+        <optgroup label="Group 2">
+          <option value="4">Option 4</option>
+          <option value="5">Option 5</option>
+          <option value="6">Option 6</option>
+        </optgroup>
+        <optgroup label="Group 3">
+          <option value="7">Option 7</option>
+          <option value="8">Option 8</option>
+          <option value="9">Option 9</option>
+        </optgroup>
+      </select>
+    </div>
+  </div>
+
+  <div class="mb-3 row">
+    <label class="col-sm-2 col-form-label">Dropdown Dividers</label>
+
+    <div class="col-sm-10">
+      <select class="form-control ms-dropdown ms-dropdown-divider" data-test="select5">
+        <optgroup label="Group 1">
+          <option value="1">Option 1</option>
+          <option value="2">Option 2</option>
+          <option value="3">Option 3</option>
+        </optgroup>
+        <optgroup label="Group 2">
+          <option value="4">Option 4</option>
+          <option value="5">Option 5</option>
+          <option value="6">Option 6</option>
+        </optgroup>
+        <optgroup label="Group 3">
+          <option value="7">Option 7</option>
+          <option value="8">Option 8</option>
+          <option value="9">Option 9</option>
+        </optgroup>
       </select>
     </div>
   </div>

--- a/demo/src/examples/example12.html
+++ b/demo/src/examples/example12.html
@@ -7,7 +7,7 @@
         <span class="small">
           <a
             target="_blank"
-            href="https://github.com/ghiscoding/multiple-select-vanilla/blob/main/demo/src/examples/example11.html"
+            href="https://github.com/ghiscoding/multiple-select-vanilla/blob/main/demo/src/examples/example12.html"
             >html</a
           >
           |

--- a/demo/src/examples/example13.html
+++ b/demo/src/examples/example13.html
@@ -7,7 +7,7 @@
         <span class="small">
           <a
             target="_blank"
-            href="https://github.com/ghiscoding/multiple-select-vanilla/blob/main/demo/src/options/options08.html"
+            href="https://github.com/ghiscoding/multiple-select-vanilla/blob/main/demo/src/options/example13.html"
             >html</a
           >
           |

--- a/demo/src/examples/example14.html
+++ b/demo/src/examples/example14.html
@@ -1,0 +1,115 @@
+<div class="row mb-2">
+  <div class="col-md-12 title-desc">
+    <h2 class="bd-title">
+      The Divider
+      <span class="float-end links">
+        Code <span class="fa fa-link"></span>
+        <span class="small">
+          <a
+            target="_blank"
+            href="https://github.com/ghiscoding/multiple-select-vanilla/blob/main/demo/src/examples/example08.html"
+            >html</a
+          >
+          |
+          <a target="_blank" href="https://github.com/ghiscoding/multiple-select-vanilla/blob/main/demo/src/examples/example08.ts"
+            >ts</a
+          >
+        </span>
+      </span>
+    </h2>
+    <div class="demo-subtitle">Display an option as a divider.</div>
+  </div>
+</div>
+
+<div>
+  <div class="mb-3 row">
+    <label class="col-sm-2">Single Select</label>
+
+    <div class="col-sm-10">
+      <select id="single" class="select full-width" data-test="single">
+        <option value="1">January</option>
+        <option value="2">February</option>
+        <option value="3">March</option>
+        <option value="4">April</option>
+        <option data-divider="true"></option>
+        <option value="5">May</option>
+        <option value="6">June</option>
+        <option value="7">July</option>
+        <option value="8">August</option>
+        <option data-divider="true"></option>
+        <option value="9">September</option>
+        <option value="10">October</option>
+        <option value="11">November</option>
+        <option value="12">December</option>
+      </select>
+    </div>
+  </div>
+
+  <div class="mb-3 row">
+    <label class="col-sm-2">Multiple Select</label>
+
+    <div class="col-sm-10">
+      <select id="multiple" class="select full-width" data-test="multiple" multiple>
+        <option value="1">January</option>
+        <option value="2">February</option>
+        <option value="3">March</option>
+        <option value="4">April</option>
+        <option data-divider="true"></option>
+        <option value="5">May</option>
+        <option value="6">June</option>
+        <option value="7">July</option>
+        <option value="8">August</option>
+        <option data-divider="true"></option>
+        <option value="9">September</option>
+        <option value="10">October</option>
+        <option value="11">November</option>
+        <option value="12">December</option>
+      </select>
+    </div>
+  </div>
+
+  <div class="mb-3 row">
+    <label class="col-sm-2">Group Select</label>
+
+    <div class="col-sm-10">
+      <select id="group" class="select full-width" data-test="group" multiple>
+        <option data-divider="true"></option>
+        <optgroup label="Group 1">
+          <option value="1">January</option>
+          <option value="2">February</option>
+          <option value="3">March</option>
+          <option data-divider="true"></option>
+          <option value="4">April</option>
+          <option value="5">May</option>
+          <option value="6">June</option>
+        </optgroup>
+        <option data-divider="true"></option>
+        <optgroup label="Group 2">
+          <option value="7">July</option>
+          <option value="8">August</option>
+          <option value="9">September</option>
+          <option data-divider="true"></option>
+          <option value="10">October</option>
+          <option value="11">November</option>
+          <option value="12">December</option>
+        </optgroup>
+      </select>
+    </div>
+  </div>
+
+  <div class="mb-3 row">
+    <label class="col-sm-2">Data Select 1</label>
+
+    <div class="col-sm-10">
+      <select id="data-select1" class="data-select full-width" data-test="data1" multiple></select>
+    </div>
+  </div>
+
+  <div class="mb-3 row">
+    <label class="col-sm-2">Data Select 2</label>
+
+    <div class="col-sm-10">
+      <select id="data-select2" class="data-select full-width" data-test="data2" multiple></select>
+    </div>
+  </div>
+</div>

--- a/demo/src/examples/example14.ts
+++ b/demo/src/examples/example14.ts
@@ -1,0 +1,50 @@
+import { multipleSelect, MultipleSelectInstance } from 'multiple-select-vanilla';
+
+export default class Example {
+  ms1: MultipleSelectInstance[] = [];
+  ms2: MultipleSelectInstance[] = [];
+
+  mount() {
+    this.ms1 = multipleSelect('.select') as MultipleSelectInstance[];
+    this.ms2 = multipleSelect('.data-select', {
+      dataTest: 'select1',
+      data: [
+        {
+          value: 1,
+          text: 'Option 1',
+        },
+        {
+          value: 2,
+          text: 'Option 2',
+        },
+        {
+          value: 3,
+          text: 'Option 3',
+        },
+        {
+          divider: true,
+        },
+        {
+          value: 4,
+          text: 'Option 4',
+        },
+        {
+          value: 5,
+          text: 'Option 5',
+        },
+        {
+          value: 6,
+          text: 'Option 6',
+        },
+      ],
+    }) as MultipleSelectInstance[];
+  }
+
+  unmount() {
+    // destroy ms instance(s) to avoid DOM leaks
+    this.ms1.forEach((m) => m.destroy());
+    this.ms2.forEach((m) => m.destroy());
+    this.ms1 = [];
+    this.ms2 = [];
+  }
+}

--- a/demo/src/methods/methods03.html
+++ b/demo/src/methods/methods03.html
@@ -31,6 +31,8 @@
     <div class="col-sm-10">
       <button id="setSelectsBtn" class="btn btn-secondary">SetSelects</button>
       <button id="getSelectsBtn" class="btn btn-secondary">GetSelects</button>
+      <button id="setSelectsBtn2" class="btn btn-secondary">SetSelects by 'text'</button>
+      <button id="getSelectsBtn2" class="btn btn-secondary">GetSelects by 'text'</button>
     </div>
   </div>
 

--- a/demo/src/methods/methods03.ts
+++ b/demo/src/methods/methods03.ts
@@ -16,6 +16,14 @@ export default class Example {
       alert(`Selected values: ${this.ms1?.getSelects()}`);
       alert(`Selected texts: ${this.ms1?.getSelects('text')}`);
     });
+
+    document.querySelector('#setSelectsBtn2')!.addEventListener('click', () => {
+      this.ms1?.setSelects(['February', 'April'], 'text');
+    });
+
+    document.querySelector('#getSelectsBtn2')!.addEventListener('click', () => {
+      alert(`Selected values: ${this.ms1?.getSelects('text')}`);
+    });
   }
 
   unmount() {

--- a/demo/src/methods/methods12.html
+++ b/demo/src/methods/methods12.html
@@ -1,0 +1,44 @@
+<div class="row mb-2">
+  <div class="col-md-12 title-desc">
+    <h2 class="bd-title">
+      The getData
+      <span class="float-end links">
+        Code <span class="fa fa-link"></span>
+        <span class="small">
+          <a
+            target="_blank"
+            href="https://github.com/ghiscoding/multiple-select-vanilla/blob/main/demo/src/methods/methods01.html"
+            >html</a
+          >
+          |
+          <a target="_blank" href="https://github.com/ghiscoding/multiple-select-vanilla/blob/main/demo/src/methods/methods01.ts"
+            >ts</a
+          >
+        </span>
+      </span>
+    </h2>
+    <div class="demo-subtitle">Use <code>multipleSelect('getData')</code> to get the loaded data.</div>
+  </div>
+</div>
+
+<div>
+  <div class="mb-3 row">
+    <label class="col-sm-2">Methods</label>
+
+    <div class="col-sm-10">
+      <button id="getData" class="btn btn-secondary">getData</button>
+    </div>
+  </div>
+
+  <div class="mb-3 row">
+    <label class="col-sm-2">Basic Select</label>
+
+    <div class="col-sm-10">
+      <select multiple="multiple" class="full-width">
+        <option value="text1">text1</option>
+        <option value="text2">text2</option>
+        <option value="text3">text3</option>
+      </select>
+    </div>
+  </div>
+</div>

--- a/demo/src/methods/methods12.ts
+++ b/demo/src/methods/methods12.ts
@@ -1,0 +1,22 @@
+import { MultipleSelectInstance, multipleSelect } from 'multiple-select-vanilla';
+
+export default class Example {
+  ms1?: MultipleSelectInstance;
+
+  mount() {
+    this.ms1 = multipleSelect('select', {
+      filter: true,
+    }) as MultipleSelectInstance;
+
+    document.querySelector('#getData')!.addEventListener('click', () => {
+      console.log('tt', JSON.stringify(this.ms1!.getData()));
+      alert(JSON.stringify(this.ms1!.getData(), null, 4));
+    });
+  }
+
+  unmount() {
+    // destroy ms instance(s) to avoid DOM leaks
+    this.ms1?.destroy();
+    this.ms1 = undefined;
+  }
+}

--- a/demo/src/options/options23.ts
+++ b/demo/src/options/options23.ts
@@ -1,4 +1,4 @@
-import { multipleSelect, MultipleSelectInstance } from 'multiple-select-vanilla';
+import { multipleSelect, MultipleSelectInstance, type TextFilter } from 'multiple-select-vanilla';
 
 export default class Example {
   ms1?: MultipleSelectInstance;
@@ -6,11 +6,11 @@ export default class Example {
   mount() {
     this.ms1 = multipleSelect('select', {
       filter: true,
-      customFilter: (label, text, originalLabel, originalText) => {
+      customFilter: ({ text, search, originalText, originalSearch }: TextFilter) => {
         if (document.querySelector('input')!.checked) {
-          return originalLabel.indexOf(originalText) === 0;
+          return originalText.indexOf(originalSearch) === 0;
         }
-        return label.indexOf(text) === 0;
+        return text.indexOf(search) === 0;
       },
     }) as MultipleSelectInstance;
   }

--- a/demo/src/options/options25.html
+++ b/demo/src/options/options25.html
@@ -7,7 +7,7 @@
         <span class="small">
           <a
             target="_blank"
-            href="https://github.com/ghiscoding/multiple-select-vanilla/blob/main/demo/src/options/options24.html"
+            href="https://github.com/ghiscoding/multiple-select-vanilla/blob/main/demo/src/options/options25.html"
             >html</a
           >
           |

--- a/demo/src/options/options26.html
+++ b/demo/src/options/options26.html
@@ -7,7 +7,7 @@
         <span class="small">
           <a
             target="_blank"
-            href="https://github.com/ghiscoding/multiple-select-vanilla/blob/main/demo/src/options/options25.html"
+            href="https://github.com/ghiscoding/multiple-select-vanilla/blob/main/demo/src/options/options26.html"
             >html</a
           >
           |

--- a/demo/src/options/options27.html
+++ b/demo/src/options/options27.html
@@ -7,7 +7,7 @@
         <span class="small">
           <a
             target="_blank"
-            href="https://github.com/ghiscoding/multiple-select-vanilla/blob/main/demo/src/options/options26.html"
+            href="https://github.com/ghiscoding/multiple-select-vanilla/blob/main/demo/src/options/options27.html"
             >html</a
           >
           |

--- a/demo/src/options/options27.ts
+++ b/demo/src/options/options27.ts
@@ -1,13 +1,20 @@
-import { multipleSelect, MultipleSelectInstance } from 'multiple-select-vanilla';
+import { multipleSelect, MultipleSelectInstance, TextFilter } from 'multiple-select-vanilla';
 
 export default class Example {
   ms1?: MultipleSelectInstance;
 
   mount() {
     this.ms1 = multipleSelect('select', {
+      filter: true,
       renderOptionLabelAsHtml: true, // without this flag, html code will be showing as plain text
       textTemplate: (el) => {
         return `<i class="fa fa-star"></i>${el.innerHTML}`;
+      },
+      customFilter: ({ search, text }: TextFilter) => {
+        // create a temp html element to get only the text to search against
+        const divElm = document.createElement('div');
+        divElm.innerHTML = text;
+        return divElm.textContent?.includes(search) ?? true;
       },
     }) as MultipleSelectInstance;
   }

--- a/demo/src/options/options28.html
+++ b/demo/src/options/options28.html
@@ -7,7 +7,7 @@
         <span class="small">
           <a
             target="_blank"
-            href="https://github.com/ghiscoding/multiple-select-vanilla/blob/main/demo/src/options/options27.html"
+            href="https://github.com/ghiscoding/multiple-select-vanilla/blob/main/demo/src/options/options28.html"
             >html</a
           >
           |

--- a/demo/src/options/options29.html
+++ b/demo/src/options/options29.html
@@ -7,7 +7,7 @@
         <span class="small">
           <a
             target="_blank"
-            href="https://github.com/ghiscoding/multiple-select-vanilla/blob/main/demo/src/options/options08.html"
+            href="https://github.com/ghiscoding/multiple-select-vanilla/blob/main/demo/src/options/options29.html"
             >html</a
           >
           |

--- a/demo/src/options/options31.html
+++ b/demo/src/options/options31.html
@@ -7,7 +7,7 @@
         <span class="small">
           <a
             target="_blank"
-            href="https://github.com/ghiscoding/multiple-select-vanilla/blob/main/demo/src/options/options08.html"
+            href="https://github.com/ghiscoding/multiple-select-vanilla/blob/main/demo/src/options/options31.html"
             >html</a
           >
           |

--- a/demo/src/options/options32.html
+++ b/demo/src/options/options32.html
@@ -7,7 +7,7 @@
         <span class="small">
           <a
             target="_blank"
-            href="https://github.com/ghiscoding/multiple-select-vanilla/blob/main/demo/src/options/options08.html"
+            href="https://github.com/ghiscoding/multiple-select-vanilla/blob/main/demo/src/options/options32.html"
             >html</a
           >
           |

--- a/demo/src/options/options33.html
+++ b/demo/src/options/options33.html
@@ -1,13 +1,13 @@
 <div class="row mb-2">
   <div class="col-md-12 title-desc">
     <h2 class="bd-title">
-      Auto-Adjust Drop Height/Width
+      Classes
       <span class="float-end links">
         Code <span class="fa fa-link"></span>
         <span class="small">
           <a
             target="_blank"
-            href="https://github.com/ghiscoding/multiple-select-vanilla/blob/main/demo/src/options/options30.html"
+            href="https://github.com/ghiscoding/multiple-select-vanilla/blob/main/demo/src/options/options08.html"
             >html</a
           >
           |
@@ -18,19 +18,17 @@
       </span>
     </h2>
     <div class="demo-subtitle">
-      Use <code>autoAdjustDropWidthByTextSize</code> to automatically adjust the drop width by the largest option width from the
-      found in the list. <br />
-      Use <code>autoAdjustDropHeight</code> to automatically adjust the drop max height calculated from the available space.
+      Use <code>classes</code>, <code>classPrefix</code>, <code>size</code> to define the class and size of select.
     </div>
   </div>
 </div>
 
 <div>
   <div class="mb-3 row">
-    <label class="col-sm-3 text-end">Adjust drop width by option list content</label>
+    <label class="col-sm-2 col-form-label col-form-label-sm">Small Select</label>
 
     <div class="col-sm-9">
-      <select id="select1" multiple="multiple" data-width="75" data-test="select1">
+      <select id="select1" multiple="multiple" class="full-width" data-size="sm" data-test="select1" placeholder="data-size='sm'">
         <option value="1">January</option>
         <option value="2">February</option>
         <option value="3">March</option>
@@ -48,10 +46,10 @@
   </div>
 
   <div class="mb-3 row">
-    <label class="col-sm-3 text-end">Resize drop height (width: 200px)</label>
+    <label class="col-sm-2 col-form-label">Normal Select</label>
 
     <div class="col-sm-9">
-      <select id="select2" multiple="multiple" data-width="200" data-test="select2">
+      <select id="select2" multiple="multiple" class="full-width" data-test="select2">
         <option value="1">January</option>
         <option value="2">February</option>
         <option value="3">March</option>
@@ -69,10 +67,10 @@
   </div>
 
   <div class="mb-3 row">
-    <label class="col-sm-3 text-end">Resize drop height (width: auto)</label>
+    <label class="col-sm-2 col-form-label col-form-label-lg">Large Select</label>
 
     <div class="col-sm-9">
-      <select id="select3" multiple="multiple" data-test="select3">
+      <select id="select3" multiple="multiple" data-size="lg" data-test="select3" placeholder="data-size='lg'">
         <option value="1">January</option>
         <option value="2">February</option>
         <option value="3">March</option>
@@ -88,17 +86,5 @@
       </select>
     </div>
   </div>
-
-  <div class="mb-3 row">
-    <label class="col-sm-3 text-end"> Dropdown width </label>
-
-    <div class="col-sm-9">
-      <select id="select4" data-width="200" data-test="select4">
-        <option value="1">This is the first option and value is 1</option>
-        <option value="2">This is the second option and value is 2</option>
-        <option value="3">This is the third option and value is 3</option>
-        <option value="4">This is the fourth option and value is 4</option>
-      </select>
-    </div>
   </div>
 </div>

--- a/demo/src/options/options33.ts
+++ b/demo/src/options/options33.ts
@@ -1,0 +1,19 @@
+import { multipleSelect, MultipleSelectInstance } from 'multiple-select-vanilla';
+import 'multiple-select-vanilla/dist/styles/sass/themes/bootstrap.scss';
+
+export default class Example {
+  ms: MultipleSelectInstance[] = [];
+
+  mount() {
+    this.ms = multipleSelect('select', {
+      classes: 'form-control',
+      classPrefix: 'form-control',
+    }) as MultipleSelectInstance[];
+  }
+
+  unmount() {
+    // destroy ms instance(s) to avoid DOM leaks
+    this.ms.forEach((m) => m.destroy());
+    this.ms = [];
+  }
+}

--- a/lib/src/constants.ts
+++ b/lib/src/constants.ts
@@ -1,4 +1,4 @@
-import { MultipleSelectOption } from './interfaces';
+import { LabelFilter, MultipleSelectOption, TextFilter } from './interfaces';
 import English from './locales/multiple-select-en-US';
 
 const BLOCK_ROWS = 50;
@@ -7,6 +7,8 @@ const CLUSTER_BLOCKS = 4;
 const DEFAULTS: Partial<MultipleSelectOption> = {
   name: '',
   placeholder: '',
+  classes: '',
+  classPrefix: '',
   data: undefined,
   locale: undefined,
 
@@ -38,9 +40,9 @@ const DEFAULTS: Partial<MultipleSelectOption> = {
   filterPlaceholder: '',
   filterAcceptOnEnter: false,
   filterByDataLength: undefined,
-  customFilter(label: string, text: string) {
-    // originalLabel, originalText
-    return label.includes(text);
+  customFilter(filterOptions) {
+    const { text, label, search } = filterOptions as LabelFilter & TextFilter;
+    return (label || text || '').includes(search);
   },
 
   showClear: false,

--- a/lib/src/interfaces/interfaces.ts
+++ b/lib/src/interfaces/interfaces.ts
@@ -1,4 +1,9 @@
 export type OptionDataObject = { [value: string]: number | string | boolean };
+
+export interface OptionRowDivider {
+  divider: boolean;
+}
+
 export interface OptionRowData {
   text: string;
   value: string | number | boolean;
@@ -44,4 +49,21 @@ export interface MultipleSelectLocale {
 
 export interface MultipleSelectLocales {
   [localeKey: string]: MultipleSelectLocale;
+}
+
+export interface LabelFilter {
+  label: string;
+  search: string;
+  originalLabel: string;
+  originalSearch: string;
+  row: OptionRowData | OptGroupRowData;
+}
+
+export interface TextFilter {
+  text: string;
+  search: string;
+  originalText: string;
+  originalSearch: string;
+  row: OptionRowData | OptGroupRowData;
+  parent?: OptionRowData | OptGroupRowData;
 }

--- a/lib/src/interfaces/multipleSelectOption.interface.ts
+++ b/lib/src/interfaces/multipleSelectOption.interface.ts
@@ -1,4 +1,4 @@
-import { MultipleSelectLocale, OptGroupRowData, OptionRowData } from './interfaces';
+import { LabelFilter, MultipleSelectLocale, OptGroupRowData, OptionRowData, OptionRowDivider, TextFilter } from './interfaces';
 
 export interface MultipleSelectView {
   label: string;
@@ -26,6 +26,12 @@ export interface MultipleSelectOption extends MultipleSelectLocale {
   /** Drop menu to automatically set its width as the maximum available width of text */
   autoAdjustDropWidthByTextSize?: boolean;
 
+  /** The class name of select. */
+  classes?: string;
+
+  /** The class prefix of select. */
+  classPrefix?: string;
+
   /** HTML container to use for the drop menu, e.g. 'body' */
   container?: string | HTMLElement | null;
 
@@ -33,7 +39,9 @@ export interface MultipleSelectOption extends MultipleSelectLocale {
   countSelectedText?: string;
 
   /** provide custom data */
-  data?: { [value: string]: number | string | boolean } | Array<number | string | boolean | OptionRowData | OptGroupRowData>;
+  data?:
+    | { [value: string]: number | string | boolean }
+    | Array<number | string | boolean | OptionRowData | OptionRowDivider | OptGroupRowData>;
 
   /** Add "data-test" attribute to the "ms-parent" element */
   dataTest?: string;
@@ -140,6 +148,9 @@ export interface MultipleSelectOption extends MultipleSelectLocale {
   /** Alias to `single` */
   singleRadio?: boolean;
 
+  /** The size of select. */
+  size?: number | string;
+
   /** Show a clear button, defaults to false */
   showClear?: boolean;
 
@@ -160,7 +171,7 @@ export interface MultipleSelectOption extends MultipleSelectLocale {
   // ------------
 
   /** Customize the filter method, for example we use startWith */
-  customFilter: (normalizedText: string, normalizedOriginalText: string, text: string, originalText: string) => boolean;
+  customFilter(options: LabelFilter | TextFilter): boolean;
 
   /** The item styler function, return style string to custom the item style such as background: red. The function take one parameter: value. */
   styler: (value: OptionRowData | OptGroupRowData) => string | boolean | null;

--- a/lib/src/styles/multiple-select.scss
+++ b/lib/src/styles/multiple-select.scss
@@ -1,4 +1,3 @@
-/* css/sass variables */
 @import './variables';
 
 /*!
@@ -77,9 +76,6 @@
         content: '×';
         color: #888;
         font-weight: bold;
-        position: absolute;
-        top: 50%;
-        margin-top: -14px;
       }
 
       &:hover:before {

--- a/lib/src/utils/utils.ts
+++ b/lib/src/utils/utils.ts
@@ -114,7 +114,7 @@ export function removeUndefined(obj: any) {
   return obj;
 }
 
-export function removeDiacritics(str: any) {
+export function removeDiacritics(str: string): string {
   if (typeof str !== 'string') {
     return str;
   }

--- a/playwright/e2e/example14.spec.ts
+++ b/playwright/e2e/example14.spec.ts
@@ -1,0 +1,54 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Example 14 - The Divider', () => {
+  test('multiple select with divider list items', async ({ page }) => {
+    await page.goto('#/example14');
+
+    await page.locator('div[data-test=single] .ms-choice').filter({ hasText: 'January' }).click();
+    const li1LabelElms = await page.locator('div[data-test=single] li.hide-radio');
+    const li1DividerElms = await page.locator('div[data-test=single] li.option-divider');
+    await page.locator('div[data-test=single] .ms-drop li label').filter({ hasText: 'March' }).click();
+    await expect(li1LabelElms).toHaveCount(12);
+    await expect(li1DividerElms).toHaveCount(2);
+
+    await page.locator('div[data-test=multiple] .ms-choice').click();
+    const li2LabelElms = await page.locator('div[data-test=multiple] li:not(.option-divider)');
+    const li2DividerElms = await page.locator('div[data-test=multiple] li.option-divider');
+    await expect(li2LabelElms).toHaveCount(13);
+    await expect(li2DividerElms).toHaveCount(2);
+    await page.locator('div[data-test=multiple] span').filter({ hasText: 'February' }).click();
+    const parent2Span = await page.locator('div[data-test=multiple] .ms-choice span');
+    await page.getByRole('button', { name: 'February' }).click();
+    await expect(parent2Span).toHaveText('February');
+
+    await page.locator('div[data-test=group] .ms-choice').click();
+    const li3LabelElms = await page.locator('div[data-test=group] li:not(.option-divider)');
+    const li3DividerElms = await page.locator('div[data-test=group] li.option-divider');
+    await expect(li3LabelElms).toHaveCount(15);
+    await expect(li3DividerElms).toHaveCount(4);
+    await page.getByText('Group 1').click();
+    await page.locator('div[data-test=group].ms-parent').click();
+    const parent3Span = await page.locator('div[data-test=group] .ms-choice span');
+    await expect(parent3Span).toHaveText('6 of 12 selected');
+
+    await page.locator('div[data-test=data1] .ms-choice').click();
+    const li4LabelElms = await page.locator('div[data-test=data1] li:not(.option-divider)');
+    const li4DividerElms = await page.locator('div[data-test=data1] li.option-divider');
+    await expect(li4LabelElms).toHaveCount(7);
+    await expect(li4DividerElms).toHaveCount(1);
+    await page.locator('div[data-test=data1] span').filter({ hasText: 'Option 2' }).click();
+    const parent4Span = await page.locator('div[data-test=data1] .ms-choice span');
+    await page.getByRole('button', { name: 'Option 2' }).click();
+    await expect(parent4Span).toHaveText('Option 2');
+
+    await page.locator('div[data-test=data2] .ms-choice').click();
+    const li5LabelElms = await page.locator('div[data-test=data2] li:not(.option-divider)');
+    const li5DividerElms = await page.locator('div[data-test=data2] li.option-divider');
+    await expect(li5LabelElms).toHaveCount(7);
+    await expect(li5DividerElms).toHaveCount(1);
+    await page.locator('div[data-test=data2] span').filter({ hasText: 'Option 6' }).click();
+    const parent5Span = await page.locator('div[data-test=data2] .ms-choice span');
+    await page.locator('div[data-test=data2].ms-parent').click();
+    await expect(parent5Span).toHaveText('Option 2, Option 6');
+  });
+});

--- a/playwright/e2e/methods01.spec.ts
+++ b/playwright/e2e/methods01.spec.ts
@@ -14,6 +14,8 @@ test.describe('Methods 01 - getOptions()', () => {
       `{`,
       `"name": "",`,
       `"placeholder": "",`,
+      `"classes": "",`,
+      `"classPrefix": "",`,
       `"selectAll": true,`,
       `"single": false,`,
       `"singleRadio": false,`,

--- a/playwright/e2e/methods03.spec.ts
+++ b/playwright/e2e/methods03.spec.ts
@@ -9,9 +9,14 @@ test.describe('Methods 03 - setSelects() / getSelects()', () => {
     });
 
     await page.goto('#/methods03');
-    await page.getByRole('button', { name: 'SetSelects' }).click();
-    await page.getByRole('button', { name: 'GetSelects' }).click();
+
+    await page.locator('#setSelectsBtn').click();
+    await page.locator('#getSelectsBtn').click();
     expect(dialogTexts[0]).toBe('Selected values: 1,3');
     expect(dialogTexts[1]).toBe('Selected texts: January,March');
+
+    await page.locator('#setSelectsBtn2').click();
+    await page.locator('#getSelectsBtn2').click();
+    expect(dialogTexts[2]).toBe('Selected values: February,April');
   });
 });

--- a/playwright/e2e/methods12.spec.ts
+++ b/playwright/e2e/methods12.spec.ts
@@ -1,0 +1,50 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Methods 12 - getData()', () => {
+  test('method returns default options when calling the method', async ({ page }) => {
+    let dialogText = '';
+    page.on('dialog', async (alert) => {
+      dialogText = alert.message();
+      await alert.dismiss();
+    });
+
+    await page.goto('#/methods12');
+    await page.getByRole('button', { name: 'getData' }).click();
+    const str = `[
+    {
+        \"type\": \"option\",
+        \"text\": \"text1\",
+        \"value\": \"text1\",
+        \"visible\": true,
+        \"selected\": false,
+        \"disabled\": false,
+        \"classes\": \"\",
+        \"title\": \"\",
+        \"_key\": \"option_0\"
+    },
+    {
+        \"type\": \"option\",
+        \"text\": \"text2\",
+        \"value\": \"text2\",
+        \"visible\": true,
+        \"selected\": false,
+        \"disabled\": false,
+        \"classes\": \"\",
+        \"title\": \"\",
+        \"_key\": \"option_1\"
+    },
+    {
+        \"type\": \"option\",
+        \"text\": \"text3\",
+        \"value\": \"text3\",
+        \"visible\": true,
+        \"selected\": false,
+        \"disabled\": false,
+        \"classes\": \"\",
+        \"title\": \"\",
+        \"_key\": \"option_2\"
+    }
+]`;
+    await expect(dialogText).toContain(str);
+  });
+});

--- a/playwright/e2e/options33.spec.ts
+++ b/playwright/e2e/options33.spec.ts
@@ -1,0 +1,21 @@
+import { test, expect, Page } from '@playwright/test';
+
+async function assertDropHeight(page: Page, selector: string, expectation: number, range = 3) {
+  const dropElm = await page.locator(selector);
+  const dropElmBB = await dropElm?.boundingBox();
+  const elmHeight = dropElmBB?.height ?? 0;
+  expect(elmHeight).toBeGreaterThanOrEqual(expectation - range);
+  expect(elmHeight).toBeLessThan(expectation + range);
+}
+
+test.describe('Example 33 - Classes', () => {
+  test('select element have different element height & text font size', async ({ page }) => {
+    await page.goto('#/options33');
+    await page.locator('div.form-control-sm').click();
+    await page.getByRole('listitem').filter({ hasText: 'January' }).locator('span').click();
+
+    await assertDropHeight(page, '[data-test=select1] .ms-choice', 29);
+    await assertDropHeight(page, '[data-test=select2] .ms-choice', 36);
+    await assertDropHeight(page, '[data-test=select3] .ms-choice', 46);
+  });
+});


### PR DESCRIPTION
- follows original ms-select [v1.6.0](https://github.com/wenzhixin/multiple-select/releases/tag/1.6.0) that was released recently, this PR includes the changes as follow:
- added `setSelects` by text support.
- added `divider` option support.
- added `classes`, `classPrefix` and `size` options.
- added `dropdown` support for bootstrap theme.
- added `getData` method.
- fixed clear button display error.
- updated the default parameter of `customFilter` option, changes the argument signature from multiple arguments to a single object argument that accepts multiple options (this is a breaking change)
- added 3 new demo pages:
   - [The Divider - Example 14](https://ghiscoding.github.io/multiple-select-vanilla/#/example14)
   - [Classes - Options 33](https://ghiscoding.github.io/multiple-select-vanilla/#/options33)
   - [The getData - Methods 12](https://ghiscoding.github.io/multiple-select-vanilla/#/methods12)
- also modified a few examples as well
   - [The Theme - Example 11](https://ghiscoding.github.io/multiple-select-vanilla/#/example11)
   - [getSelects / setSelects - Methods 03](https://ghiscoding.github.io/multiple-select-vanilla/#/methods03)
   - [customFilter - Options 23](https://ghiscoding.github.io/multiple-select-vanilla/#/options23)
   - [textTemplate - Options 27](https://ghiscoding.github.io/multiple-select-vanilla/#/options27)
  