### PR TITLE
fix: replace some DOM Element method not supported in Salesforce

### DIFF
--- a/lib/src/MultipleSelectInstance.ts
+++ b/lib/src/MultipleSelectInstance.ts
@@ -79,7 +79,7 @@ export class MultipleSelectInstance {
       if (hardDestroy) {
         this.options.onHardDestroy();
       }
-      if (this.elm?.parentElement && this.parentElm?.parentElement) {
+      if (this.elm.parentElement && this.parentElm.parentElement) {
         this.elm.parentElement.insertBefore(this.elm, this.parentElm.parentElement!.firstChild);
       }
       this.elm.classList.remove('ms-offscreen');

--- a/lib/src/MultipleSelectInstance.ts
+++ b/lib/src/MultipleSelectInstance.ts
@@ -79,7 +79,9 @@ export class MultipleSelectInstance {
       if (hardDestroy) {
         this.options.onHardDestroy();
       }
-      this.elm.before(this.parentElm);
+      if (this.elm?.parentElement && this.parentElm?.parentElement) {
+        this.elm.parentElement.insertBefore(this.elm, this.parentElm.parentElement!.firstChild);
+      }
       this.elm.classList.remove('ms-offscreen');
       this._bindEventService.unbindAll();
 


### PR DESCRIPTION
some methods aren't supported in Salesforce for unknown reasons and it throws some errors like "append function does not exist"