### PR TITLE
fix: placeholder text shouldn't be escaped

### DIFF
--- a/lib/src/MultipleSelectInstance.ts
+++ b/lib/src/MultipleSelectInstance.ts
@@ -191,7 +191,8 @@ export class MultipleSelectInstance {
       this.choiceElm.tabIndex = +tabIndex;
     }
 
-    this.choiceElm.appendChild(createDomElement('span', { className: 'ms-placeholder', textContent: this.options.placeholder }));
+    const placeholderText = this.options.sanitizer ? this.options.sanitizer(this.options.placeholder) : this.options.placeholder;
+    this.choiceElm.appendChild(createDomElement('span', { className: 'ms-placeholder', innerHTML: placeholderText }));
 
     if (this.options.showClear) {
       this.choiceElm.appendChild(createDomElement('div', { className: 'icon-close' }));


### PR DESCRIPTION
- in some cases, some text were being escaped as html special char and was different, for example 50" (inch) was being escaped and shown as 50&quot;