### PR TITLE
fix: CJS fallbacks should be at the end not at beginning

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -2,8 +2,6 @@
   "name": "multiple-select-vanilla",
   "version": "0.4.4",
   "type": "module",
-  "main": "./dist/cjs/multiple-select.js",
-  "module": "./dist/esm/multiple-select.js",
   "exports": {
     ".": {
       "import": "./dist/esm/multiple-select.js",
@@ -21,6 +19,8 @@
     }
   },
   "types": "./dist/types/index.d.ts",
+  "main": "./dist/cjs/multiple-select.js",
+  "module": "./dist/esm/multiple-select.js",
   "files": [
     "dist"
   ],


### PR DESCRIPTION
- when defining the old CJS `main` and `module`, these properties should come after `exports` (new ESM prop) so that newer Node will try `exports` first and not try fallback first, while for old Node it will automatically use the fallbacks since `exports` won't work, see this TypeScript for more info (https://www.typescriptlang.org/docs/handbook/esm-node.html)