### PR TITLE
perf: use array of html struct instead of plain HTML Element

### DIFF
--- a/lib/src/interfaces/interfaces.ts
+++ b/lib/src/interfaces/interfaces.ts
@@ -1,16 +1,29 @@
+/* eslint-disable @typescript-eslint/indent */
+export type InferDOMType<T> = T extends CSSStyleDeclaration ? Partial<CSSStyleDeclaration> : T extends infer R ? R : any;
+/* eslint-enable @typescript-eslint/indent */
+
 export type OptionDataObject = { [value: string]: number | string | boolean };
 
 export interface OptionRowDivider {
   divider: boolean;
 }
 
+export interface HtmlStruct {
+  tagName: keyof HTMLElementTagNameMap;
+  props?: any;
+  attrs?: Record<any, string>;
+  children?: HtmlStruct[];
+}
+
 export interface OptionRowData {
   text: string;
   value: string | number | boolean;
+  classes?: string;
   divider?: string;
   disabled?: boolean;
   selected?: boolean | number;
   visible?: boolean | string;
+  title?: string;
   type?: 'option' | 'optgroup';
   _key?: string;
   _value?: string | number | boolean;
@@ -22,8 +35,15 @@ export interface OptGroupRowData extends Omit<OptionRowData, 'text' | 'value'> {
   children: Array<OptionRowData>;
 }
 
+export interface VirtualCache {
+  bottom: number;
+  data: HtmlStruct[];
+  scrollTop: number;
+  top: number;
+}
+
 export interface VirtualScrollOption {
-  rows: HTMLElement[];
+  rows: HtmlStruct[];
   scrollEl: HTMLElement;
   contentEl: HTMLElement;
   callback: () => void;

--- a/lib/src/services/virtual-scroll.ts
+++ b/lib/src/services/virtual-scroll.ts
@@ -1,20 +1,13 @@
 import Constants from '../constants';
-import { VirtualScrollOption } from '../interfaces';
-import { emptyElement } from '../utils';
-
-interface VirtualCache {
-  bottom: number;
-  data: HTMLElement[];
-  scrollTop: number;
-  top: number;
-}
+import { HtmlStruct, VirtualCache, VirtualScrollOption } from '../interfaces';
+import { convertItemRowToHtml, emptyElement } from '../utils';
 
 export class VirtualScroll {
   cache: VirtualCache;
   clusterRows?: number;
   dataStart!: number;
   dataEnd!: number;
-  rows: HTMLElement[];
+  rows: HtmlStruct[];
   scrollEl: HTMLElement;
   blockHeight?: number;
   clusterHeight?: number;
@@ -56,13 +49,14 @@ export class VirtualScroll {
     };
   }
 
-  initDOM(rows: HTMLElement[]) {
+  initDOM(rows: HtmlStruct[]) {
     if (typeof this.clusterHeight === 'undefined') {
       this.cache.scrollTop = this.scrollEl.scrollTop;
+      const firstRowElm = convertItemRowToHtml(rows[0]);
 
-      this.contentEl.appendChild(rows[0]);
-      this.contentEl.appendChild(rows[0]);
-      this.contentEl.appendChild(rows[0]);
+      this.contentEl.appendChild(firstRowElm);
+      this.contentEl.appendChild(firstRowElm);
+      this.contentEl.appendChild(firstRowElm);
       this.cache.data = [rows[0]];
       this.getRowsHeight();
     }
@@ -78,7 +72,7 @@ export class VirtualScroll {
       if (data.topOffset) {
         this.contentEl.appendChild(this.getExtra('top', data.topOffset));
       }
-      data.rows.forEach((h) => this.contentEl.appendChild(h));
+      data.rows.forEach((h) => this.contentEl.appendChild(convertItemRowToHtml(h)));
 
       if (data.bottomOffset) {
         this.contentEl.appendChild(this.getExtra('bottom', data.bottomOffset));
@@ -116,7 +110,7 @@ export class VirtualScroll {
     return 0;
   }
 
-  initData(rows: HTMLElement[], num: number) {
+  initData(rows: HtmlStruct[], num: number) {
     if (rows.length < Constants.BLOCK_ROWS) {
       return {
         topOffset: 0,
@@ -129,7 +123,7 @@ export class VirtualScroll {
     const end = start + this.clusterRows!;
     const topOffset = Math.max(start * this.itemHeight!, 0);
     const bottomOffset = Math.max((rows.length - end) * this.itemHeight!, 0);
-    const thisRows: HTMLElement[] = [];
+    const thisRows: HtmlStruct[] = [];
     let rowsAbove = start;
     if (topOffset < 1) {
       rowsAbove++;


### PR DESCRIPTION
- the previous migration to plain/pure HTML Element was great for CSP but keeping a large array of HTMLElement can consume a lot of memory and is not the fastest especially when dealing with large dataset (thousand of items), what we can do instead of keep a minimal html struct (html tag name and the props/attrs that we are interested only), so whenever we need to recreate the list of element it is much quicker to create basic struct than it is to create thousand of HTMLElement and it consumes a lot less memory.
- perf seems to double when using html struct instead of plain HTMLElement
- the perf comparison was mostly done in the [Large Dataset](https://ghiscoding.github.io/multiple-select-vanilla/#/example10) example which is where this PR will have the biggest impact