### PR TITLE
fix: input checkbox value should always be included even when null

### DIFF
--- a/lib/src/utils/domUtils.ts
+++ b/lib/src/utils/domUtils.ts
@@ -99,7 +99,7 @@ export function createDomStructure(item: HtmlStruct, appendToElm?: HTMLElement, 
     delete item.props.innerHTML;
   }
 
-  const elm = createDomElement(item.tagName, objectRemoveEmptyProps(item.props), appendToElm);
+  const elm = createDomElement(item.tagName, objectRemoveEmptyProps(item.props, ['class', 'title', 'style']), appendToElm);
   let parent: HTMLElement | null | undefined = parentElm;
   if (!parent) {
     parent = elm;

--- a/lib/src/utils/utils.ts
+++ b/lib/src/utils/utils.ts
@@ -54,8 +54,20 @@ export function isDefined(val: any) {
   return val !== undefined && val !== null && val !== '';
 }
 
-export function objectRemoveEmptyProps(obj: any) {
+/**
+ * Remove all empty props from an object, 
+ * we can optionally provide a fixed list of props to consider for removal (anything else will be excluded)
+ * @param {*} obj 
+ * @param {Array<String>} [clearProps] - optional list of props to consider for removal (anything else will be excluded)
+ * @returns cleaned object
+ */
+export function objectRemoveEmptyProps(obj: any, clearProps?: string[]) {
   if (typeof obj === 'object') {
+    if (clearProps) {
+      return Object.fromEntries(
+        Object.entries(obj).filter(([name, val]) => (!isDefined(val) && !clearProps.includes(name)) || isDefined(val))
+      );
+    }
     return Object.fromEntries(Object.entries(obj).filter(([_, v]) => isDefined(v)));
   }
   return obj;


### PR DESCRIPTION
- last version refactoring removed all empty props & attributes when creating DOM element but we should never remove input `value` prop even when it is null or empty 