### PR TITLE
chore: serve prod build to run E2E tests without using Vite dev mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "new-publish": "lerna publish from-package",
     "preroll-new-release": "echo Please update getting-started lib version before pushing release. ⚠️",
     "roll-new-release": "pnpm build && pnpm new-version && pnpm new-publish",
-    "serve:demo": "pnpm -r --stream --filter=\"{demo/**}\" dev",
+    "serve:demo": "servor ./docs index.html 3000",
     "test:e2e": "playwright test --config playwright/playwright.config.ts",
     "test:e2e:debug": "playwright test --config playwright/playwright.config.ts --ui --debug",
     "test:e2e:ui": "playwright test --config playwright/playwright.config.ts --ui",
@@ -69,6 +69,7 @@
     "pnpm": "^8.10.3",
     "prettier": "^3.1.0",
     "rimraf": "^5.0.5",
+    "servor": "^4.0.2",
     "typescript": "^5.2.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       rimraf:
         specifier: ^5.0.5
         version: 5.0.5
+      servor:
+        specifier: ^4.0.2
+        version: 4.0.2
       typescript:
         specifier: ^5.2.2
         version: 5.2.2
@@ -1837,7 +1840,7 @@ packages:
       normalize-path: 3.0.0
       readdirp: 3.6.0
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.3
     dev: true
 
   /chownr@2.0.0:
@@ -5699,6 +5702,11 @@ packages:
     hasBin: true
     dependencies:
       lru-cache: 6.0.0
+    dev: true
+
+  /servor@4.0.2:
+    resolution: {integrity: sha512-MlmQ5Ntv4jDYUN060x/KEmN7emvIqKMZ9OkM+nY8Bf2+KkyLmGsTqWLyAN2cZr5oESAcH00UanUyyrlS1LRjFw==}
+    hasBin: true
     dev: true
 
   /set-blocking@2.0.0:


### PR DESCRIPTION
- use `servor` to serve a Prod build