### PR TITLE
fix: revert to using `.js` for both CJS/ESM

### DIFF
--- a/lib/build-prod.mjs
+++ b/lib/build-prod.mjs
@@ -6,7 +6,7 @@ const localeFiles = globSync('src/locales/**/*.ts');
 const localeEntryPoints = [];
 
 for (const format of buildFormats) {
-  const extension = format === 'cjs' ? 'cjs' : 'js';
+  const extension = format === 'cjs' ? 'js' : 'js';
   // multiple-select.js
   runBuild({
     format,
@@ -22,7 +22,7 @@ for (const format of buildFormats) {
       runBuild({
         entryPoints: [`src/locales/multiple-select-${locale}.ts`],
         format,
-        outfile: `dist/locales/multiple-select-${locale}.${extension}`,
+        outfile: `dist/locales${format === 'cjs' ? '-cjs' : ''}/multiple-select-${locale}.${extension}`,
       });
     }
   }
@@ -31,7 +31,7 @@ for (const format of buildFormats) {
   runBuild({
     entryPoints: ['./src/locales/all-locales-index.ts'],
     format,
-    outfile: `dist/locales/multiple-select-all-locales.${extension}`,
+    outfile: `dist/locales${format === 'cjs' ? '-cjs' : ''}/multiple-select-all-locales.${extension}`,
   });
 
   // finally, create a regular bundle as a standalone which will be accessible as MultipleSelect from the global window object
@@ -39,7 +39,7 @@ for (const format of buildFormats) {
   runBuild({
     format,
     globalName: 'MultipleSelect',
-    outfile: `dist/browser/multiple-select.${extension}`,
+    outfile: `dist/browser${format === 'cjs' ? '-cjs' : ''}/multiple-select.${extension}`,
   });
 }
 

--- a/lib/build-watch.mjs
+++ b/lib/build-watch.mjs
@@ -36,8 +36,8 @@ function runLocaleBuild() {
   // merge all Locales into a single file "multiple-select-all-locales.js"
   runBuild({
     entryPoints: ['./src/locales/all-locales-index.ts'],
-    format: 'iife',
-    outfile: `dist/multiple-select-all-locales.js`,
+    format: 'esm',
+    outfile: `dist/locales/multiple-select-all-locales.js`,
   });
 }
 

--- a/lib/package.json
+++ b/lib/package.json
@@ -20,7 +20,9 @@
       "default": "./dist/esm/multiple-select.js"
     },
     "./dist/browser/*": "./dist/browser/*",
+    "./dist/browser-cjs/*": "./dist/browser/*",
     "./dist/locales/*": "./dist/locales/*",
+    "./dist/locales-cjs/*": "./dist/locales/*",
     "./dist/styles/*": "./dist/styles/*",
     "./package.json": "./package.json"
   },

--- a/lib/package.json
+++ b/lib/package.json
@@ -2,7 +2,7 @@
   "name": "multiple-select-vanilla",
   "version": "1.0.1",
   "type": "module",
-  "main": "./dist/cjs/multiple-select.cjs",
+  "main": "./dist/cjs/multiple-select.js",
   "module": "./dist/esm/multiple-select.js",
   "types": "index.d.ts",
   "typesVersions": {
@@ -15,8 +15,8 @@
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
-      "node": "./dist/cjs/multiple-select.cjs",
-      "require": "./dist/cjs/multiple-select.cjs",
+      "node": "./dist/cjs/multiple-select.js",
+      "require": "./dist/cjs/multiple-select.js",
       "default": "./dist/esm/multiple-select.js"
     },
     "./dist/browser/*": "./dist/browser/*",


### PR DESCRIPTION
- however to keep using `.js` for both builds, it requires us to separate files, since we prefer ESM, we will only add `-cjs` to 2 folders (`locales-cjs` and `browser-cjs`)

The reason is because of the new result from [Are the Types wrong?](https://arethetypeswrong.github.io/?p=multiple-select-vanilla%401.0.1) website, the hope is to fix this masquerade which we didn't have before 1.0 release


![image](https://github.com/ghiscoding/multiple-select-vanilla/assets/643976/0013610f-89b6-4d0a-8afd-612645e8d7d4)
