### PR TITLE
feat: add tabindex to list item to control up/down arrow direction

### DIFF
--- a/lib/src/utils/domUtils.ts
+++ b/lib/src/utils/domUtils.ts
@@ -99,7 +99,7 @@ export function createDomStructure(item: HtmlStruct, appendToElm?: HTMLElement, 
     delete item.props.innerHTML;
   }
 
-  const elm = createDomElement(item.tagName, objectRemoveEmptyProps(item.props, ['class', 'title', 'style']), appendToElm);
+  const elm = createDomElement(item.tagName, objectRemoveEmptyProps(item.props, ['className', 'title', 'style']), appendToElm);
   let parent: HTMLElement | null | undefined = parentElm;
   if (!parent) {
     parent = elm;

--- a/playwright/e2e/example02.spec.ts
+++ b/playwright/e2e/example02.spec.ts
@@ -8,8 +8,25 @@ test.describe('Example 02 - Multiple Select', () => {
     await page.locator('span').filter({ hasText: 'April' }).click();
     await page.locator('span').filter({ hasText: 'May' }).click();
     const parent1Span = await page.locator('div[data-test=select1] .ms-choice span');
-    await page.getByRole('button', { name: 'February, April, May' }).click();
+
     await expect(parent1Span).toHaveText('February, April, May');
+    await page.keyboard.press('ArrowDown');
+    const juneLoc = await page.locator('div[data-test=select1] .ms-drop li:nth-of-type(6)');
+    await expect(juneLoc).toBeFocused();
+    await expect(await juneLoc.locator('label')).toHaveText('June');
+    await page.keyboard.press('Enter');
+    await expect(parent1Span).toHaveText('4 of 12 selected');
+
+    // go up until we reach "Select All" and use Space to press the option
+    page.keyboard.press('ArrowUp');
+    page.keyboard.press('ArrowUp');
+    page.keyboard.press('ArrowUp');
+    page.keyboard.press('ArrowUp');
+    page.keyboard.press('ArrowUp');
+    page.keyboard.press('ArrowUp');
+    page.keyboard.press('Space');
+    await expect(parent1Span).toHaveText('All selected');
+    await page.getByRole('button', { name: 'All selected' }).click();
   });
 
   test('second select with multiple selection with optgroup and expect entire group to be selected', async ({ page }) => {

--- a/playwright/e2e/example03.spec.ts
+++ b/playwright/e2e/example03.spec.ts
@@ -6,12 +6,20 @@ test.describe('Example 03 - Multiple Width', () => {
     await page.locator('div[data-test=select1].ms-parent').click();
     await page.getByRole('listitem').filter({ hasText: '30' }).locator('label').click();
     await page.getByRole('checkbox', { name: '15' }).check();
-    const elm16 = await page.locator('label').filter({ hasText: '16' });
+    let elm16 = await page.locator('label').filter({ hasText: '16' });
     await elm16.click();
     expect((await elm16!.boundingBox())!.width).toBe(44);
+
+    elm16 = await page.locator('div[data-test=select1] .ms-drop li:nth-of-type(16)');
+    await elm16.focus();
+    await expect(elm16).toBeFocused();
+    await page.keyboard.press('ArrowUp');
+    await page.keyboard.press('Space'); // unselect 15
+    let parent1Span = await page.locator('div[data-test=select1] .ms-choice span');
+    await expect(parent1Span).toHaveText('16, 30');
+    await page.keyboard.press('Enter'); // reselect 15
+    parent1Span = await page.locator('div[data-test=select1] .ms-choice span');
     await page.getByRole('button', { name: '15, 16, 30' }).click();
-    const parent1Span = await page.locator('div[data-test=select1] .ms-choice span');
-    await expect(parent1Span).toHaveText('15, 16, 30');
   });
 
   test('second select and expect optgroup selection to select the entire group when optgroup is selected', async ({ page }) => {
@@ -34,6 +42,18 @@ test.describe('Example 03 - Multiple Width', () => {
     await page.getByRole('checkbox', { name: '3', exact: true }).check();
     const selectAll2 = await page.locator('[data-test=select2] .ms-select-all input[data-name=selectAll]');
     await expect(selectAll2).toBeChecked();
-    await page.getByRole('button', { name: 'All selected' }).click();
+    await page.getByRole('button', { name: 'All selected' });
+    const selectAllLoc = await page.locator('div[data-test=select2] .ms-drop .ms-select-all');
+    await selectAllLoc.focus();
+    await page.keyboard.press('ArrowDown'); // unselect Group 1
+    await page.keyboard.press('Space');
+    let parent2Span = await page.locator('div[data-test=select2] .ms-choice span');
+    await expect(parent2Span).toHaveText('10 of 15 selected');
+    await page.keyboard.press('ArrowDown'); // unselect Group 1 -> 1st item
+    await page.keyboard.press('Enter');
+    parent2Span = await page.locator('div[data-test=select2] .ms-choice span');
+    await expect(parent2Span).toHaveText('11 of 15 selected');
+    const group1item1Loc = await page.locator('[data-test=select2] .ms-drop li:nth-of-type(2) input');
+    await expect(group1item1Loc).toBeChecked();
   });
 });


### PR DESCRIPTION
- add tabIndex on every list item and select-all checkbox so that we can use up/down arrows to focus on next or previous item.
- divider will be skipped and ignored
- using Enter or Space key will select/unselect the input checkbox of the current item

![brave_JqP0OMAlaj](https://github.com/ghiscoding/multiple-select-vanilla/assets/643976/5d8e2d64-5a8b-461b-a6a7-67f82f603fca)
