### PR TITLE
chore: add demo for built-in diacritic parser [refresh gh-pages]

### DIFF
--- a/packages/demo/src/options/options35.html
+++ b/packages/demo/src/options/options35.html
@@ -18,7 +18,8 @@
       </span>
     </h2>
     <div class="demo-subtitle">
-      Use <code>diacriticParser</code> callback option to remove diacritic signs (accents) from text while filtering items.
+      Use <code>diacriticParser</code> callback option to remove diacritic signs (accents) from text while filtering items. 
+      For example searching with "Fév" or "Fev" will return "Février" in both cases
     </div>
   </div>
 </div>
@@ -38,10 +39,31 @@
   <hr/>
 
   <div class="mb-3 row">
-    <label class="col-sm-2 text-end">Select</label>
+    <label class="col-sm-2 text-end">Custom Parser</label>
 
     <div class="col-sm-9">
       <select id="select1" multiple="multiple" data-test="select1" class="full-width">
+        <option value="1">Janvier</option>
+        <option value="2">Février</option>
+        <option value="3">Mars</option>
+        <option value="4">Avril</option>
+        <option value="5">Mai</option>
+        <option value="6">Juin</option>
+        <option value="7">Juillet</option>
+        <option value="8">Août</option>
+        <option value="9">Septembre</option>
+        <option value="10">Octobre</option>
+        <option value="11">Novembre</option>
+        <option value="12">Décembre</option>
+      </select>
+    </div>
+  </div>
+
+  <div class="mb-3 row">
+    <label class="col-sm-2 text-end">Default Built-in Parser</label>
+
+    <div class="col-sm-9">
+      <select id="select2" multiple="multiple" data-test="select2" class="full-width">
         <option value="1">Janvier</option>
         <option value="2">Février</option>
         <option value="3">Mars</option>

--- a/packages/demo/src/options/options35.ts
+++ b/packages/demo/src/options/options35.ts
@@ -20,6 +20,7 @@ const diacritics = {
 
 export default class Example {
   ms1?: MultipleSelectInstance;
+  ms2?: MultipleSelectInstance;
   inLogElm!: HTMLInputElement;
   outLogElm!: HTMLInputElement;
 
@@ -29,7 +30,7 @@ export default class Example {
     this.ms1 = multipleSelect('#select1', {
       filter: true,
       showSearchClear: true,
-      placeholder: 'search with "é" or "û"',
+      filterPlaceholder: '🔎︎ search with "é", "û" or simply "u"',
       diacriticParser: (text: string) => {
         const output = text
           .split('')
@@ -41,11 +42,20 @@ export default class Example {
         return output;
       },
     }) as MultipleSelectInstance;
+
+    // default built-in diacritic parser (it uses the `normalize()` method)
+    this.ms2 = multipleSelect('#select2', {
+      filter: true,
+      showSearchClear: true,
+      filterPlaceholder: '🔎︎ search with "é", "û" or simply "u"',
+    }) as MultipleSelectInstance;
   }
 
   unmount() {
     // destroy ms instance(s) to avoid DOM leaks
     this.ms1?.destroy();
+    this.ms2?.destroy();
     this.ms1 = undefined;
+    this.ms2 = undefined;
   }
 }

--- a/packages/multiple-select-vanilla/src/styles/_variables.scss
+++ b/packages/multiple-select-vanilla/src/styles/_variables.scss
@@ -67,6 +67,7 @@ $ms-search-input-border-radius: 5px !default;
 $ms-search-input-min-height: 24px !default;
 $ms-search-input-margin: 0 !default;
 $ms-search-input-padding: 0 5px !default;
+$ms-search-input-placeholder: #999 !default;
 $ms-select-all-border-bottom: 1px solid #ddd !default;
 $ms-select-all-label-border: $ms-item-border !default;
 $ms-select-all-label-hover-border: 1px solid transparent !default;

--- a/packages/multiple-select-vanilla/src/styles/multiple-select.scss
+++ b/packages/multiple-select-vanilla/src/styles/multiple-select.scss
@@ -197,6 +197,9 @@
     min-height: var(--ms-search-input-min-height, $ms-search-input-min-height);
     padding: var(--ms-search-input-padding, $ms-search-input-padding);
     margin: var(--ms-search-input-margin, $ms-search-input-margin);
+    &::placeholder {
+      color: var(--ms-search-input-placeholder, $ms-search-input-placeholder);
+    }
   }
 
   span.icon-close {

--- a/playwright/e2e/options35.spec.ts
+++ b/playwright/e2e/options35.spec.ts
@@ -4,12 +4,14 @@ test.describe('Options 35 - Diacritic Parser', () => {
   test('filtering on all type of select & clear search input', async ({ page }) => {
     await page.goto('#/options35');
 
+    // 1st Select
+    // --------------
     await page.locator('[data-test=select1].ms-parent').click();
     await page.getByRole('textbox', { name: '🔎︎' }).fill('év');
     await page.keyboard.press('Enter');
     await page.locator('[data-test=select1] span').filter({ hasText: 'Février' }).click();
-    const selectAll3 = await page.locator('[data-test=select1] .ms-select-all input[type=checkbox]');
-    expect(selectAll3).toBeChecked();
+    const selectAll1 = await page.locator('[data-test=select1] .ms-select-all input[type=checkbox]');
+    expect(selectAll1).toBeChecked();
     await expect(page.locator('input.in-log')).toHaveValue('év');
     await expect(page.locator('input.out-log')).toHaveValue('ev');
     await expect(page.locator('[data-test=select1].ms-drop li:not(.ms-no-results)')).toHaveCount(1);
@@ -39,5 +41,41 @@ test.describe('Options 35 - Diacritic Parser', () => {
     await page.locator('[data-test=select1] span').filter({ hasText: 'Août' }).click();
     const parentSpan = await page.locator('div[data-test=select1] .ms-choice span');
     await expect(parentSpan).toHaveText('Février, Juin, Août');
+    await page.locator('[data-test=select1].ms-parent').click();
+
+    // 2nd Select
+    // --------------
+    await page.locator('[data-test=select2].ms-parent').click();
+    await page.getByRole('textbox', { name: '🔎︎' }).fill('év');
+    await page.keyboard.press('Enter');
+    await page.locator('[data-test=select2] span').filter({ hasText: 'Février' }).click();
+    const selectAll2 = await page.locator('[data-test=select2] .ms-select-all input[type=checkbox]');
+    expect(selectAll2).toBeChecked();
+    await expect(page.locator('[data-test=select2].ms-drop li:not(.ms-no-results)')).toHaveCount(1);
+    await page.locator('[data-test=select2].ms-parent').click();
+
+    await page.locator('[data-test=select2].ms-parent').click();
+    await page.locator('[data-test=select2] .ms-search .icon-close').click();
+    await expect(page.locator('[data-test=select2] .ms-search span')).toHaveText('');
+    await expect(page.locator('[data-test=select2].ms-drop li:not(.ms-no-results)')).toHaveCount(12);
+
+    await page.getByRole('textbox', { name: '🔎︎' }).fill('e');
+    await page.keyboard.press('Enter');
+    await expect(page.locator('[data-test=select2].ms-drop li:not(.ms-no-results)')).toHaveCount(7);
+    await page.locator('[data-test=select2] .ms-search .icon-close').click();
+    await expect(page.locator('[data-test=select2] .ms-search span')).toHaveText('');
+
+    await page.getByRole('textbox', { name: '🔎︎' }).fill('û');
+    await page.keyboard.press('Enter');
+    await expect(page.locator('[data-test=select2].ms-drop li:not(.ms-no-results)')).toHaveCount(3);
+    await page.locator('[data-test=select2] .ms-search .icon-close').click();
+    await page.getByRole('textbox', { name: '🔎︎' }).fill('u');
+    await page.keyboard.press('Enter');
+    await page.locator('[data-test=select2] span').filter({ hasText: 'Juin' }).click();
+    await page.locator('[data-test=select2] span').filter({ hasText: 'Juillet' });
+    await page.locator('[data-test=select2] span').filter({ hasText: 'Août' }).click();
+    const parentSpan2 = await page.locator('div[data-test=select2] .ms-choice span');
+    await expect(parentSpan2).toHaveText('Février, Juin, Août');
+    await page.locator('[data-test=select2].ms-parent').click();
   });
 });


### PR DESCRIPTION
- adding a 2nd Select since we should  also have E2E tests for our built-in parser which uses `str.normalize('NFD')`