### PR TITLE
fix(npm): publish src folder for source maps

### DIFF
--- a/packages/multiple-select-vanilla/package.json
+++ b/packages/multiple-select-vanilla/package.json
@@ -24,7 +24,8 @@
     "./package.json": "./package.json"
   },
   "files": [
-    "dist"
+    "/dist",
+    "/src"
   ],
   "author": {
     "name": "zhixin wen",


### PR DESCRIPTION
for source map to work properly, the `src/` folder must be included while running npm publish