### PR TITLE
fix: should not add `multipleSelect` on `window` obj for all bundlers

### DIFF
--- a/packages/multiple-select-vanilla/build-prod.mjs
+++ b/packages/multiple-select-vanilla/build-prod.mjs
@@ -38,7 +38,7 @@ for (const format of buildFormats) {
   // this file is basically a legacy alternative to import via a <script> tag
   runBuild({
     format,
-    globalName: 'MultipleSelect',
+    globalName: 'multipleSelect',
     outfile: `dist/browser/multiple-select.${extension}`,
   });
 }

--- a/packages/multiple-select-vanilla/src/multiple-select.ts
+++ b/packages/multiple-select-vanilla/src/multiple-select.ts
@@ -64,8 +64,3 @@ function _multipleSelect(
 multipleSelect.defaults = Constants.DEFAULTS;
 multipleSelect.locales = { ...English } as MultipleSelectLocales; // load English as default locale
 multipleSelect.methods = Constants.METHODS;
-
-// add it to the window object so it can be used as standalone
-if (typeof window !== 'undefined') {
-  window.multipleSelect = multipleSelect;
-}


### PR DESCRIPTION
- previous code was adding `multipleSelect` to the `window` for all distributed builds (IIFE/CJS/ESM) but in practice it's already added by esbuild on the IIFE (Browser) build and we shouldn't add it ourselves, just let esbuild handle it for IIFE only. In other words the CJS/ESM also had `multipleSelect` on the `window` object but that was wrong