### PR TITLE
feat!: replace arrow up/down direction tabIndex by highlight, fix #206

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -83,6 +83,7 @@ jobs:
         run: pnpm test:e2e
 
       - name: Upload Event File
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: Event File

--- a/packages/demo/src/app-routing.ts
+++ b/packages/demo/src/app-routing.ts
@@ -81,7 +81,7 @@ export const exampleRouting = [
       { name: 'example07', view: '/src/examples/example07.html', viewModel: Example07, title: 'Submit Select' },
       { name: 'example08', view: '/src/examples/example08.html', viewModel: Example08, title: 'The Data' },
       { name: 'example09', view: '/src/examples/example09.html', viewModel: Example09, title: 'Locale' },
-      { name: 'example10', view: '/src/examples/example10.html', viewModel: Example10, title: 'Large Select' },
+      { name: 'example10', view: '/src/examples/example10.html', viewModel: Example10, title: 'Large Select (Virtual Scroll)' },
       { name: 'example11', view: '/src/examples/example11.html', viewModel: Example11, title: 'The Themes' },
       { name: 'example12', view: '/src/examples/example12.html', viewModel: Example12, title: 'Checkbox/Radio Icons' },
       { name: 'example13', view: '/src/examples/example13.html', viewModel: Example13, title: 'Dynamically Create Select' },

--- a/packages/demo/src/examples/example10.html
+++ b/packages/demo/src/examples/example10.html
@@ -1,7 +1,7 @@
 <div class="row mb-2">
   <div class="col-md-12 title-desc">
     <h2 class="bd-title">
-      Large Select
+      Large Select - Virtual Scroll
       <span class="float-end links">
         Code <span class="fa fa-link"></span>
         <span class="small">

--- a/packages/demo/src/style.scss
+++ b/packages/demo/src/style.scss
@@ -1,5 +1,10 @@
 @use 'sass:math';
 
+// $body-color: #ccc;
+$primary: teal;
+$btn-color: #fff;
+
+@import 'bootstrap';
 @import 'multiple-select-vanilla/dist/styles/css/multiple-select.css';
 
 $navbar-height: 60px;

--- a/packages/demo/vite.config.mts
+++ b/packages/demo/vite.config.mts
@@ -5,6 +5,7 @@ export default defineConfig({
   server: {
     port: 3000,
     cors: true,
+    open: true,
     host: 'localhost',
   },
 });

--- a/packages/multiple-select-vanilla/src/MultipleSelectInstance.ts
+++ b/packages/multiple-select-vanilla/src/MultipleSelectInstance.ts
@@ -954,7 +954,8 @@ export class MultipleSelectInstance {
             break;
           case 'Enter':
           case ' ':
-            if (e.key === ' ' && this.options.filter) {
+            const liElm = e.target.closest('.ms-select-all') || e.target.closest('li');
+            if ((e.key === ' ' && this.options.filter) || (this.options.filterAcceptOnEnter && !liElm)) {
               return;
             }
             e.preventDefault();

--- a/packages/multiple-select-vanilla/src/services/virtual-scroll.ts
+++ b/packages/multiple-select-vanilla/src/services/virtual-scroll.ts
@@ -44,8 +44,8 @@ export class VirtualScroll {
 
     this.scrollEl.addEventListener('scroll', onScroll, false);
     this.destroy = () => {
-      emptyElement(this.contentEl);
       this.scrollEl.removeEventListener('scroll', onScroll, false);
+      emptyElement(this.contentEl);
     };
   }
 

--- a/packages/multiple-select-vanilla/src/styles/_variables.scss
+++ b/packages/multiple-select-vanilla/src/styles/_variables.scss
@@ -1,11 +1,12 @@
 /*
  * Multiple-Select-Vanilla SASS variables
  */
-$primary-color: #000 !default;
+$primary-color: #149085 !default;
 
 $ms-item-border: 1px solid transparent !default;
 $ms-item-hover-border: 1px solid #d5d5d5 !default;
 $ms-checkbox-hover-bg-color: #fafafa !default;
+$ms-checkbox-color: $primary-color !default;
 $ms-choice-border: 1px solid #aaa !default;
 $ms-choice-bgcolor: #fff !default;
 $ms-choice-disabled-bgcolor: #f4f4f4 !default;
@@ -25,7 +26,7 @@ $ms-drop-hide-radio-hover-bgcolor: #f8f9fa !default;
 $ms-drop-hide-radio-label-margin-bottom: 0 !default;
 $ms-drop-hide-radio-label-padding: 5px 8px !default;
 $ms-drop-hide-radio-selected-color: #fff !default;
-$ms-drop-hide-radio-selected-bgcolor: #007bff !default;
+$ms-drop-hide-radio-selected-bgcolor: $primary-color !default;
 $ms-drop-input-margin-left: -1.25rem !default;
 $ms-drop-input-margin-top: 0.3rem !default;
 $ms-drop-optgroup-font-weight: bold !default;
@@ -42,9 +43,11 @@ $ms-drop-list-item-padding: 0.25rem 8px !default;
 $ms-drop-list-item-disabled-filter: Alpha(Opacity = 35) !default;
 $ms-drop-list-item-disabled-opacity: 0.35 !default;
 $ms-drop-zindex: 1050 !default;
+$ms-input-focus-outline: none !default;
 $ms-label-margin-bottom: 0 !default;
 $ms-label-min-height: 1.25rem !default;
 $ms-label-padding: 0 0 0 1.25rem !default;
+$ms-option-highlight: rgba($primary-color, 8%) !default;
 $ms-ok-button-bg-color: #fff !default;
 $ms-ok-button-bg-hover-color: #f9f9f9 !default;
 $ms-ok-button-border-color: #ccc !default;
@@ -71,7 +74,6 @@ $ms-search-input-placeholder: #999 !default;
 $ms-select-all-border-bottom: 1px solid #ddd !default;
 $ms-select-all-label-border: $ms-item-border !default;
 $ms-select-all-label-hover-border: 1px solid transparent !default;
-$ms-select-all-label-hover-bg-color: $ms-checkbox-hover-bg-color !default;
 $ms-select-all-label-padding: 4px !default;
 $ms-select-all-label-span-padding: 0 0 0 20px !default;
 $ms-select-all-line-height: 18px !default;

--- a/packages/multiple-select-vanilla/src/styles/multiple-select.scss
+++ b/packages/multiple-select-vanilla/src/styles/multiple-select.scss
@@ -133,6 +133,9 @@
     &:hover {
       background-color: var(--ms-select-all-text-hover-color, $ms-select-all-text-hover-color);
     }
+    &.highlighted {
+      background-color: var(--ms-option-highlight, $ms-option-highlight);
+    }
 
     label {
       display: inline-block;
@@ -144,7 +147,6 @@
       &:hover {
         cursor: pointer;
         border: var(--ms-select-all-label-hover-border, $ms-select-all-label-hover-border);
-        background-color: var(--ms-select-all-label-hover-bg-color, $ms-select-all-label-hover-bg-color);
       }
       input {
         margin-left: 0;
@@ -309,6 +311,9 @@
         padding: var(--ms-drop-option-divider-padding, $ms-drop-option-divider-padding);
         border-top: var(--ms-drop-option-divider-border-top, $ms-drop-option-divider-border-top);
       }
+      &.highlighted {
+        background-color: var(--ms-option-highlight, $ms-option-highlight);
+      }
     }
   }
 
@@ -318,6 +323,10 @@
       position: absolute;
       margin-left: var(--ms-drop-input-margin-left, $ms-drop-input-margin-left);
       margin-top: var(--ms-drop-input-margin-top, $ms-drop-input-margin-top);
+      accent-color: var(--ms-checkbox-color, $ms-checkbox-color);
+    }
+    &:focus { 
+      outline: var(--ms-input-focus-outline, $ms-input-focus-outline);
     }
   }
 

--- a/playwright/e2e/events.spec.ts
+++ b/playwright/e2e/events.spec.ts
@@ -56,8 +56,7 @@ test.describe('Events Demo', () => {
       ].join('\n')
     );
 
-    await page.locator('.ms-search input').fill('1');
-    await page.keyboard.press('Enter');
+    await page.locator('.ms-search input').pressSequentially('1');
     await expect(textareaLoc).toHaveText(
       [
         'onAfterCreate event fire!',

--- a/playwright/e2e/example02.spec.ts
+++ b/playwright/e2e/example02.spec.ts
@@ -12,7 +12,7 @@ test.describe('Example 02 - Multiple Select', () => {
     await expect(parent1Span).toHaveText('February, April, May');
     await page.keyboard.press('ArrowDown');
     const juneLoc = await page.locator('div[data-test=select1] .ms-drop li:nth-of-type(6)');
-    await expect(juneLoc).toBeFocused();
+    await expect(juneLoc).toHaveClass('highlighted');
     await expect(await juneLoc.locator('label')).toHaveText('June');
     await page.keyboard.press('Enter');
     await expect(parent1Span).toHaveText('4 of 12 selected');

--- a/playwright/e2e/example03.spec.ts
+++ b/playwright/e2e/example03.spec.ts
@@ -4,7 +4,8 @@ test.describe('Example 03 - Multiple Width', () => {
   test('each item should be around 44px wide and expect item selected to show in select parent element', async ({ page }) => {
     await page.goto('#/example03');
     await page.locator('div[data-test=select1].ms-parent').click();
-    await page.getByRole('listitem').filter({ hasText: '30' }).locator('label').click();
+    await page.getByRole('combobox').filter({ hasText: '30' }).locator('label');
+    await page.getByRole('option', { name: '30' }).locator('label').click();
     await page.getByRole('checkbox', { name: '15' }).check();
     let elm16 = await page.locator('label').filter({ hasText: '16' });
     await elm16.click();
@@ -12,7 +13,7 @@ test.describe('Example 03 - Multiple Width', () => {
 
     elm16 = await page.locator('div[data-test=select1] .ms-drop li:nth-of-type(16)');
     await elm16.focus();
-    await expect(elm16).toBeFocused();
+    await expect(elm16).toHaveClass('multiple highlighted selected');
     await page.keyboard.press('ArrowUp');
     await page.keyboard.press('Space'); // unselect 15
     let parent1Span = await page.locator('div[data-test=select1] .ms-choice span');
@@ -32,11 +33,11 @@ test.describe('Example 03 - Multiple Width', () => {
     await page.getByRole('button', { name: '4 of 15 selected' }).click();
     await page.getByRole('button', { name: '4 of 15 selected' }).click();
     await page.getByText('Group 2').click();
-    await page.getByRole('listitem').filter({ hasText: '11' }).locator('label').click();
-    await page.getByRole('listitem').filter({ hasText: '12' }).locator('span').click();
-    await page.getByRole('listitem').filter({ hasText: '13' }).locator('span').click();
-    await page.getByRole('listitem').filter({ hasText: '14' }).locator('span').click();
-    await page.getByRole('listitem').filter({ hasText: '15' }).locator('span').click();
+    await page.getByRole('option', { name: '11' }).locator('label').click();
+    await page.getByRole('option', { name: '12' }).locator('span').click();
+    await page.getByRole('option', { name: '13' }).locator('span').click();
+    await page.getByRole('option', { name: '14' }).locator('span').click();
+    await page.getByRole('option', { name: '15' }).locator('span').click();
     await page.getByRole('button', { name: '14 of 15 selected' }).click();
     await page.getByRole('button', { name: '14 of 15 selected' }).click();
     await page.getByRole('checkbox', { name: '3', exact: true }).check();
@@ -44,7 +45,7 @@ test.describe('Example 03 - Multiple Width', () => {
     await expect(selectAll2).toBeChecked();
     await page.getByRole('button', { name: 'All selected' });
     const selectAllLoc = await page.locator('div[data-test=select2] .ms-drop .ms-select-all');
-    await selectAllLoc.focus();
+    await selectAllLoc.hover();
     await page.keyboard.press('ArrowDown'); // unselect Group 1
     await page.keyboard.press('Space');
     let parent2Span = await page.locator('div[data-test=select2] .ms-choice span');

--- a/playwright/e2e/example04.spec.ts
+++ b/playwright/e2e/example04.spec.ts
@@ -24,12 +24,12 @@ test.describe('Example 04 - Select Auto-Width', () => {
 
     assertDropWidth(page, 'div[data-test=select3].ms-parent', 315);
     await page.getByRole('button', { name: 'This is the first option and value is 1' }).first().click();
-    await page.getByRole('listitem').filter({ hasText: 'This is the fourth option and value is 4' }).locator('label').click();
+    await page.getByRole('option').filter({ hasText: 'This is the fourth option and value is 4' }).locator('label').click();
     await expect(page.locator('div[data-test=select3] .ms-choice span')).toHaveText('This is the fourth option and value is 4');
 
     assertDropWidth(page, 'div[data-test=select4].ms-parent', 200);
     await page.getByRole('button', { name: 'This is the first option and value is 1' }).click();
-    await page.getByRole('listitem').filter({ hasText: 'This is the fourth option and value is 4' }).locator('label').click();
+    await page.getByRole('option').filter({ hasText: 'This is the fourth option and value is 4' }).locator('label').click();
     await expect(page.locator('div[data-test=select4] .ms-choice span')).toHaveText('This is the fourth option and value is 4');
 
     assertDropWidth(page, 'div[data-test=select5].ms-parent', 120);

--- a/playwright/e2e/example07.spec.ts
+++ b/playwright/e2e/example07.spec.ts
@@ -10,7 +10,7 @@ test.describe('Example 07 - Submit Data', () => {
 
     await page.goto('#/example07');
     await page.getByRole('button', { name: 'First' }).click();
-    await page.getByRole('listitem').filter({ hasText: 'Second' }).locator('span').click();
+    await page.getByRole('option').filter({ hasText: 'Second' }).locator('span').click();
     await page.getByTestId('submit').click();
     await expect(dialogText).toBe('select1=2');
   });
@@ -26,18 +26,18 @@ test.describe('Example 07 - Submit Data', () => {
 
     await page.goto('#/example07');
     await page.locator('[data-test=select2].ms-parent').click();
-    await page.getByRole('listitem').filter({ hasText: 'Third' }).locator('span').click();
-    await page.getByRole('listitem').filter({ hasText: 'Fourth' }).locator('span').click();
+    await page.getByRole('option').filter({ hasText: 'Third' }).locator('span').click();
+    await page.getByRole('option').filter({ hasText: 'Fourth' }).locator('span').click();
     await page.getByRole('button', { name: 'Third, Fourth' }).click();
     await page.getByTestId('submit').click();
     await expect(dialogText).toBe('select1=1&select2=3&select2=4');
 
     // unselect 3,4 and select 1,2 instead
     await page.locator('[data-test=select2].ms-parent').click();
-    await page.getByRole('listitem').filter({ hasText: 'Third' }).locator('span').click();
-    await page.getByRole('listitem').filter({ hasText: 'Fourth' }).locator('span').click();
-    await page.getByRole('listitem').filter({ hasText: 'First' }).locator('span').click();
-    await page.getByRole('listitem').filter({ hasText: 'Second' }).locator('span').click();
+    await page.getByRole('option').filter({ hasText: 'Third' }).locator('span').click();
+    await page.getByRole('option').filter({ hasText: 'Fourth' }).locator('span').click();
+    await page.getByRole('option').filter({ hasText: 'First' }).locator('span').click();
+    await page.getByRole('option').filter({ hasText: 'Second' }).locator('span').click();
     await page.locator('[data-test=select2].ms-parent').click();
     await page.getByTestId('submit').click();
     await expect(dialogText).toBe('select1=1&select2=1&select2=2');

--- a/playwright/e2e/example08.spec.ts
+++ b/playwright/e2e/example08.spec.ts
@@ -4,23 +4,23 @@ test.describe('Example 08 - Data Property', () => {
   test('all select dropdown should have data', async ({ page }) => {
     await page.goto('#/example08');
     await page.locator('div[data-test=select1].ms-parent').click();
-    await page.getByRole('listitem').filter({ hasText: 'January' }).locator('span').click();
-    await page.getByRole('listitem').filter({ hasText: 'February' }).locator('span').click();
-    await page.getByRole('listitem').filter({ hasText: 'March' }).locator('label').click();
-    await page.getByRole('listitem').filter({ hasText: 'April' }).locator('label').click();
+    await page.getByRole('option').filter({ hasText: 'January' }).locator('span').click();
+    await page.getByRole('option').filter({ hasText: 'February' }).locator('span').click();
+    await page.getByRole('option').filter({ hasText: 'March' }).locator('label').click();
+    await page.getByRole('option').filter({ hasText: 'April' }).locator('label').click();
     await expect(page.locator('div[data-test=select1] .ms-choice')).toHaveText('4 of 12 selected');
     await page.locator('div[data-test=select1] .ms-choice').click();
 
     await page.locator('div[data-test=select2].ms-parent').click();
-    await page.getByRole('listitem').filter({ hasText: 'January' }).locator('span').click();
-    await page.getByRole('listitem').filter({ hasText: 'February' }).locator('span').click();
+    await page.getByRole('option').filter({ hasText: 'January' }).locator('span').click();
+    await page.getByRole('option').filter({ hasText: 'February' }).locator('span').click();
     await expect(page.locator('div[data-test=select2] .ms-choice')).toHaveText('January, February');
-    await page.getByRole('listitem').filter({ hasText: 'March' }).locator('span').click();
+    await page.getByRole('option').filter({ hasText: 'March' }).locator('span').click();
     await expect(page.locator('div[data-test=select2] .ms-choice')).toHaveText('January, February, March');
     await page.locator('div[data-test=select2] .ms-choice').click();
 
     await page.locator('div[data-test=select3].ms-parent').click();
-    await page.getByRole('listitem').filter({ hasText: 'January' }).locator('span').click();
+    await page.getByRole('option').filter({ hasText: 'January' }).locator('span').click();
     await expect(page.locator('div[data-test=select3] .ms-choice')).toHaveText('January');
     await page.locator('div[data-test=select3] .ms-select-all').click();
     await expect(page.locator('div[data-test=select3] .ms-choice')).toHaveText('All selected');
@@ -28,7 +28,7 @@ test.describe('Example 08 - Data Property', () => {
 
     // select4 with numbers
     await page.locator('div[data-test=select4].ms-parent').click();
-    await page.getByRole('listitem').filter({ hasText: '2' }).locator('span').click();
+    await page.getByRole('option').filter({ hasText: '2' }).locator('span').click();
     await expect(page.locator('div[data-test=select4] .ms-choice')).toHaveText('2');
     await page.locator('div[data-test=select4] .ms-select-all').click();
     await expect(page.locator('div[data-test=select4] .ms-choice')).toHaveText('All selected');
@@ -36,7 +36,7 @@ test.describe('Example 08 - Data Property', () => {
 
     await expect(page.locator('div[data-test=select5] .ms-choice')).toHaveText('[Group 1: January]');
     await page.locator('div[data-test=select5].ms-parent').click();
-    await page.getByRole('listitem').filter({ hasText: 'March' }).locator('label').click();
+    await page.getByRole('option').filter({ hasText: 'March' }).locator('label').click();
     await page.getByLabel('Group 2').check();
     await page.getByRole('button', { name: '8 of 12 selected' }).click();
     await page.getByRole('button', { name: '8 of 12 selected' }).click();

--- a/playwright/e2e/example11.spec.ts
+++ b/playwright/e2e/example11.spec.ts
@@ -12,7 +12,7 @@ test.describe('Example 11 - Bootstrap Theme', () => {
   test('select element have different element height & text font size', async ({ page }) => {
     await page.goto('#/example11');
     await page.getByRole('button', { name: 'form-control-sm' }).click();
-    await page.getByRole('listitem').filter({ hasText: 'January' }).locator('span').click();
+    await page.getByRole('option').filter({ hasText: 'January' }).locator('span').click();
 
     await assertDropHeight(page, '[data-test=select1] .ms-choice', 29);
     await assertDropHeight(page, '[data-test=select2] .ms-choice', 36);

--- a/playwright/e2e/example12.spec.ts
+++ b/playwright/e2e/example12.spec.ts
@@ -9,8 +9,8 @@ test.describe('Example 12 - Font Awesome', () => {
     await expect(page.locator('.ms-drop').nth(0)).not.toBeVisible();
 
     await page.locator('.ms-parent').nth(1).click();
-    await page.getByRole('listitem').filter({ hasText: 'March' }).locator('span').click();
-    await page.getByRole('listitem').filter({ hasText: 'April' }).locator('span').click();
+    await page.getByRole('option').filter({ hasText: 'March' }).locator('span').click();
+    await page.getByRole('option').filter({ hasText: 'April' }).locator('span').click();
     // await expect( page.screenshot()).toMatchSnapshot();
     await page.getByRole('button', { name: 'OK' }).click();
   });

--- a/playwright/e2e/i18n.spec.ts
+++ b/playwright/e2e/i18n.spec.ts
@@ -8,8 +8,7 @@ test.describe('I18N Demo', () => {
     await page.locator('span').filter({ hasText: 'Février' }).click();
     await page.locator('span').filter({ hasText: 'Janvier' }).click();
     await expect(page.locator('.ms-parent .ms-choice span')).toHaveText('10 de 12 sélectionnés');
-    await page.locator('.ms-search input').fill('janv');
-    await page.keyboard.press('Enter');
+    await page.locator('.ms-search input').pressSequentially('janv');
     await page.locator('span').filter({ hasText: 'Janvier' }).click();
     await page.getByText('[Tout sélectionner]').click();
     await page.getByRole('button', { name: 'Fermer' }).click();

--- a/playwright/e2e/options02.spec.ts
+++ b/playwright/e2e/options02.spec.ts
@@ -4,12 +4,12 @@ test.describe('Options 02 - Single Radio', () => {
   test('have radio button and expect drop to close after each selection', async ({ page }) => {
     await page.goto('#/options02');
     await page.locator('div[data-test="select1"] .ms-choice span', { hasText: 'First' }).click();
-    await page.getByRole('listitem').filter({ hasText: 'Third' }).locator('span').click();
+    await page.getByRole('option').filter({ hasText: 'Third' }).locator('span').click();
     const drop1elm = await page.locator('div[data-test=select1] .ms-drop');
     expect(drop1elm).toBeHidden();
 
     await page.locator('div[data-test="select2"] .ms-choice span', { hasText: 'Option 1' }).click();
-    await page.getByRole('listitem').filter({ hasText: 'Option 4' }).locator('span').click();
+    await page.getByRole('option').filter({ hasText: 'Option 4' }).locator('span').click();
     const drop2elm = await page.locator('div[data-test=select2] .ms-drop');
     expect(drop2elm).toBeHidden();
 

--- a/playwright/e2e/options17.spec.ts
+++ b/playwright/e2e/options17.spec.ts
@@ -8,23 +8,23 @@ test.describe('Options 17 - Drop Container', () => {
     expect(drop1elm).not.toBeVisible();
 
     await page.locator('.select2.ms-parent').click();
-    await page.getByRole('listitem').filter({ hasText: 'February' }).locator('span').click();
-    await page.getByRole('listitem').filter({ hasText: 'August' }).locator('span').click();
+    await page.getByRole('option').filter({ hasText: 'February' }).locator('span').click();
+    await page.getByRole('option').filter({ hasText: 'August' }).locator('span').click();
     const drop2elm = await page.locator('[data-test=select2].ms-drop');
     expect(drop2elm).toBeVisible();
     await page.getByRole('button', { name: 'February, August' }).click();
 
     await page.locator('.select3.ms-parent').click();
-    await page.getByRole('listitem').filter({ hasText: 'January' }).locator('span').click();
-    await page.getByRole('listitem').filter({ hasText: 'March' }).locator('span').click();
-    await page.getByRole('listitem').filter({ hasText: 'April' }).locator('span').click();
+    await page.getByRole('option').filter({ hasText: 'January' }).locator('span').click();
+    await page.getByRole('option').filter({ hasText: 'March' }).locator('span').click();
+    await page.getByRole('option').filter({ hasText: 'April' }).locator('span').click();
     const drop3elm = await page.locator('[data-test=select3].ms-drop');
     expect(drop3elm).toBeVisible();
     await page.getByRole('button', { name: 'January, March, April' }).click();
 
     await page.locator('.select4.ms-parent').click();
-    await page.getByRole('listitem').filter({ hasText: 'April' }).locator('span').click();
-    await page.getByRole('listitem').filter({ hasText: 'May' }).locator('span').click();
+    await page.getByRole('option').filter({ hasText: 'April' }).locator('span').click();
+    await page.getByRole('option').filter({ hasText: 'May' }).locator('span').click();
     const drop4elm = await page.locator('[data-test=select4].ms-drop');
     expect(drop4elm).toBeVisible();
     await page.getByRole('button', { name: 'April, May' }).click();

--- a/playwright/e2e/options18.spec.ts
+++ b/playwright/e2e/options18.spec.ts
@@ -4,22 +4,19 @@ test.describe('Options 18 - Drop Filtering', () => {
   test('filtering on all type of select', async ({ page }) => {
     await page.goto('#/options18');
     await page.locator('[data-test=select1].ms-parent').click();
-    await page.locator('[data-test=select1] .ms-search input').fill('gh');
-    await page.keyboard.press('Enter');
+    await page.locator('[data-test=select1] .ms-search input').pressSequentially('gh');
     await expect(page.locator('[data-test=select1].ms-drop li.hide-radio')).toHaveCount(2);
-    await page.getByRole('listitem').filter({ hasText: 'fgh' }).locator('label').click();
+    await page.getByRole('option').filter({ hasText: 'fgh' }).locator('label').click();
 
     await page.locator('[data-test=select2].ms-parent').click();
-    await page.getByRole('textbox', { name: '🔎︎' }).fill('33');
-    await page.keyboard.press('Enter');
+    await page.getByRole('textbox', { name: '🔎︎' }).pressSequentially('33');
     await expect(page.locator('[data-test=select2].ms-drop li.group')).toHaveCount(1);
     await expect(page.locator('[data-test=select2].ms-drop li.option-level-1')).toHaveCount(1);
-    await page.getByRole('listitem').filter({ hasText: 'Group 11' }).locator('label').click();
-    await page.getByRole('listitem').filter({ hasText: '333' }).locator('span').click();
+    await page.getByRole('option').filter({ hasText: 'Group 11' }).locator('label').click();
+    await page.getByRole('option').filter({ hasText: '333' }).locator('span').click();
 
     await page.locator('[data-test=select3].ms-parent').click();
-    await page.getByRole('textbox', { name: '🔎︎' }).fill('ef');
-    await page.keyboard.press('Enter');
+    await page.getByRole('textbox', { name: '🔎︎' }).pressSequentially('ef');
     await page.locator('span').filter({ hasText: 'def' }).click();
     await page.locator('span').filter({ hasText: 'efg' }).click();
     const selectAll3 = await page.locator('[data-test=select3] .ms-select-all input[type=checkbox]');
@@ -27,8 +24,7 @@ test.describe('Options 18 - Drop Filtering', () => {
     await page.locator('[data-test=select3].ms-parent').click();
 
     await page.locator('[data-test=select4].ms-parent').click();
-    await page.getByRole('textbox', { name: '🔎︎' }).fill('10');
-    await page.keyboard.press('Enter');
+    await page.getByRole('textbox', { name: '🔎︎' }).pressSequentially('10');
     await page.getByText('Group 20').click();
     await page.getByRole('button', { name: '[Group 20: 210]' }).click();
   });

--- a/playwright/e2e/options19.spec.ts
+++ b/playwright/e2e/options19.spec.ts
@@ -8,8 +8,7 @@ test.describe('Options 19 - Filter Only Optgroup', () => {
     expect(disabledLabel).toHaveText('000');
 
     await page.locator('.ms-parent').click();
-    await page.getByRole('textbox', { name: '🔎︎' }).fill('B');
-    await page.keyboard.press('Enter');
+    await page.getByRole('textbox', { name: '🔎︎' }).pressSequentially('B');
     await page.getByLabel('Group B').check();
 
     const labelElms = await page.locator('.ms-drop input[data-name="selectItem"]');

--- a/playwright/e2e/options22.spec.ts
+++ b/playwright/e2e/options22.spec.ts
@@ -5,7 +5,7 @@ test.describe('Options 22 - Filter By Data Length', () => {
     await page.goto('#/options22');
     await page.locator('[data-test="select1"].ms-parent').click();
     await expect(page.getByRole('textbox', { name: '🔎︎' })).toHaveCount(0);
-    await page.getByRole('listitem').filter({ hasText: 'abc' }).locator('label').click();
+    await page.getByRole('option').filter({ hasText: 'abc' }).locator('label').click();
 
     await page.locator('[data-test="select2"].ms-parent').click();
     await page.getByRole('textbox', { name: '🔎︎' });
@@ -21,7 +21,7 @@ test.describe('Options 22 - Filter By Data Length', () => {
     await page.getByRole('checkbox', { name: 'Group 3' }).check();
     await page.getByRole('button', { name: '5 of 11 selected' }).click();
     await page.getByRole('button', { name: '5 of 11 selected' }).click();
-    await page.getByRole('listitem').filter({ hasText: 'Group 1' }).locator('label').click();
+    await page.getByRole('option').filter({ hasText: 'Group 1' }).locator('label').click();
     await page.getByRole('button', { name: '8 of 11 selected' }).click();
   });
 });

--- a/playwright/e2e/options25.spec.ts
+++ b/playwright/e2e/options25.spec.ts
@@ -5,8 +5,8 @@ test.describe('Options 25 - Show OK Button', () => {
     await page.goto('#/options25');
     await page.locator('[data-test=select1].ms-parent').click();
     await page.getByRole('checkbox', { name: 'April' }).check();
-    await page.getByRole('listitem').filter({ hasText: 'March' }).locator('span').click();
-    await page.getByRole('listitem').filter({ hasText: 'February' }).locator('span').click();
+    await page.getByRole('option').filter({ hasText: 'March' }).locator('span').click();
+    await page.getByRole('option').filter({ hasText: 'February' }).locator('span').click();
     await page.getByRole('button', { name: 'OK' }).click();
 
     await page.locator('[data-test=select2].ms-parent').click();

--- a/playwright/e2e/options33.spec.ts
+++ b/playwright/e2e/options33.spec.ts
@@ -12,7 +12,7 @@ test.describe('Example 33 - Classes', () => {
   test('select element have different element height & text font size', async ({ page }) => {
     await page.goto('#/options33');
     await page.locator('div.form-control-sm').click();
-    await page.getByRole('listitem').filter({ hasText: 'January' }).locator('span').click();
+    await page.getByRole('option').filter({ hasText: 'January' }).locator('span').click();
 
     await assertDropHeight(page, '[data-test=select1] .ms-choice', 29);
     await assertDropHeight(page, '[data-test=select2] .ms-choice', 36);

--- a/playwright/e2e/options34.spec.ts
+++ b/playwright/e2e/options34.spec.ts
@@ -4,10 +4,9 @@ test.describe('Options 34 - Show Search Clear button', () => {
   test('filtering on all type of select & clear search input', async ({ page }) => {
     await page.goto('#/options34');
     await page.locator('[data-test=select1].ms-parent').click();
-    await page.locator('[data-test=select1] .ms-search input').fill('gh');
-    await page.keyboard.press('Enter');
+    await page.locator('[data-test=select1] .ms-search input').pressSequentially('gh');
     await expect(page.locator('[data-test=select1].ms-drop li.hide-radio')).toHaveCount(2);
-    await page.getByRole('listitem').filter({ hasText: 'fgh' }).locator('label').click();
+    await page.getByRole('option').filter({ hasText: 'fgh' }).locator('label').click();
 
     await page.locator('[data-test=select1].ms-parent').click();
     await page.locator('[data-test=select1] .ms-search .icon-close').click();
@@ -16,12 +15,11 @@ test.describe('Options 34 - Show Search Clear button', () => {
     await expect(page.locator('[data-test=select1].ms-drop li.hide-radio')).toHaveCount(31);
 
     await page.locator('[data-test=select2].ms-parent').click();
-    await page.getByRole('textbox', { name: '🔎︎' }).fill('33');
-    await page.keyboard.press('Enter');
+    await page.getByRole('textbox', { name: '🔎︎' }).pressSequentially('33');
     await expect(page.locator('[data-test=select2].ms-drop li.group')).toHaveCount(1);
     await expect(page.locator('[data-test=select2].ms-drop li.option-level-1')).toHaveCount(1);
-    await page.getByRole('listitem').filter({ hasText: 'Group 11' }).locator('label').click();
-    await page.getByRole('listitem').filter({ hasText: '333' }).locator('span').click();
+    await page.getByRole('option').filter({ hasText: 'Group 11' }).locator('label').click();
+    await page.getByRole('option').filter({ hasText: '333' }).locator('span').click();
 
     await page.locator('[data-test=select2].ms-parent').click();
     await page.locator('[data-test=select2] .ms-search .icon-close').click();
@@ -30,10 +28,9 @@ test.describe('Options 34 - Show Search Clear button', () => {
     await expect(page.locator('[data-test=select2].ms-drop li.hide-radio')).toHaveCount(37);
 
     await page.locator('[data-test=select3].ms-parent').click();
-    await page.getByRole('textbox', { name: '🔎︎' }).fill('ef');
-    await page.keyboard.press('Enter');
-    await page.locator('[data-test=select3] span').filter({ hasText: 'def' }).click();
-    await page.locator('[data-test=select3] span').filter({ hasText: 'efg' }).click();
+    await page.getByRole('textbox', { name: '🔎︎' }).pressSequentially('ef');
+    await page.getByRole('option').filter({ hasText: 'def' }).locator('span').click();
+    await page.getByRole('option').filter({ hasText: 'efg' }).locator('span').click();
     const selectAll3 = await page.locator('[data-test=select3] .ms-select-all input[type=checkbox]');
     expect(selectAll3).toBeChecked();
     await page.locator('[data-test=select3].ms-parent').click();
@@ -45,8 +42,7 @@ test.describe('Options 34 - Show Search Clear button', () => {
     await expect(page.locator('[data-test=select3].ms-drop li')).toHaveCount(32);
 
     await page.locator('[data-test=select4].ms-parent').click();
-    await page.getByRole('textbox', { name: '🔎︎' }).fill('10');
-    await page.keyboard.press('Enter');
+    await page.getByRole('textbox', { name: '🔎︎' }).pressSequentially('10');
     await page.locator('[data-test=select4] span').filter({ hasText: 'Group 20' }).click();
     await page.getByRole('button', { name: '[Group 20: 210]' }).click();
 

--- a/playwright/e2e/options35.spec.ts
+++ b/playwright/e2e/options35.spec.ts
@@ -7,8 +7,7 @@ test.describe('Options 35 - Diacritic Parser', () => {
     // 1st Select
     // --------------
     await page.locator('[data-test=select1].ms-parent').click();
-    await page.getByRole('textbox', { name: '🔎︎' }).fill('év');
-    await page.keyboard.press('Enter');
+    await page.getByRole('textbox', { name: '🔎︎' }).pressSequentially('év');
     await page.locator('[data-test=select1] span').filter({ hasText: 'Février' }).click();
     const selectAll1 = await page.locator('[data-test=select1] .ms-select-all input[type=checkbox]');
     expect(selectAll1).toBeChecked();
@@ -22,8 +21,7 @@ test.describe('Options 35 - Diacritic Parser', () => {
     await expect(page.locator('[data-test=select1] .ms-search span')).toHaveText('');
     await expect(page.locator('[data-test=select1].ms-drop li:not(.ms-no-results)')).toHaveCount(12);
 
-    await page.getByRole('textbox', { name: '🔎︎' }).fill('e');
-    await page.keyboard.press('Enter');
+    await page.getByRole('textbox', { name: '🔎︎' }).pressSequentially('e');
     await expect(page.locator('[data-test=select1].ms-drop li:not(.ms-no-results)')).toHaveCount(7);
     await page.locator('[data-test=select1] .ms-search .icon-close').click();
     await expect(page.locator('[data-test=select1] .ms-search span')).toHaveText('');
@@ -43,11 +41,10 @@ test.describe('Options 35 - Diacritic Parser', () => {
     await expect(parentSpan).toHaveText('Février, Juin, Août');
     await page.locator('[data-test=select1].ms-parent').click();
 
-    // 2nd Select
-    // --------------
+    // // 2nd Select
+    // // --------------
     await page.locator('[data-test=select2].ms-parent').click();
-    await page.getByRole('textbox', { name: '🔎︎' }).fill('év');
-    await page.keyboard.press('Enter');
+    await page.getByRole('textbox', { name: '🔎︎' }).pressSequentially('év');
     await page.locator('[data-test=select2] span').filter({ hasText: 'Février' }).click();
     const selectAll2 = await page.locator('[data-test=select2] .ms-select-all input[type=checkbox]');
     expect(selectAll2).toBeChecked();
@@ -69,13 +66,12 @@ test.describe('Options 35 - Diacritic Parser', () => {
     await page.keyboard.press('Enter');
     await expect(page.locator('[data-test=select2].ms-drop li:not(.ms-no-results)')).toHaveCount(3);
     await page.locator('[data-test=select2] .ms-search .icon-close').click();
-    await page.getByRole('textbox', { name: '🔎︎' }).fill('u');
-    await page.keyboard.press('Enter');
+    await page.getByRole('textbox', { name: '🔎︎' }).pressSequentially('u');
     await page.locator('[data-test=select2] span').filter({ hasText: 'Juin' }).click();
     await page.locator('[data-test=select2] span').filter({ hasText: 'Juillet' });
     await page.locator('[data-test=select2] span').filter({ hasText: 'Août' }).click();
     const parentSpan2 = await page.locator('div[data-test=select2] .ms-choice span');
-    await expect(parentSpan2).toHaveText('Février, Juin, Août');
+    await expect(parentSpan2).toHaveText('Juin, Août');
     await page.locator('[data-test=select2].ms-parent').click();
   });
 });


### PR DESCRIPTION
- fixes #206
- previous tabIndex implementation (in PR #176) required to use arrow to go up/down the list OR use filter (when enabled) BUT not both at the same time, this new implementation is more UX friendly and is typically what most user will want which is to keep filter in focus but also allow to use up/down arrow at the same time
- tabIndex has many drawbacks, mostly related to the fact that you can only work with current focused item, but on the other hand when switching to highlight, we can keep focus on the filter while still using the arrow to go up/down the list of select options
- using mouse hover will also update the current option highlight to mouse position
- also change selection and checkbox to use default primary color
- considering this as a breaking (major) change since using tabIndex (before) vs highlight (after) is entirely different in its usage

## _single select_

![brave_Ykv1tJw0Tm](https://github.com/ghiscoding/multiple-select-vanilla/assets/643976/e7035f4d-7256-4331-a525-4c406b771543)

## _skip disabled options_

![brave_clmA5jEPJd](https://github.com/ghiscoding/multiple-select-vanilla/assets/643976/2dfb9365-aecf-499c-888d-97422514a11f)

## _large dataset with virtual-scroll_ 

![brave_psWv19sLjL](https://github.com/ghiscoding/multiple-select-vanilla/assets/643976/dde4b280-48f5-4b52-9054-a9b2da8a9869)
