### PR TITLE
fix: query DOM element without role for cross-platform compatibility

### DIFF
--- a/packages/multiple-select-vanilla/src/MultipleSelectInstance.ts
+++ b/packages/multiple-select-vanilla/src/MultipleSelectInstance.ts
@@ -20,8 +20,8 @@ import {
 } from './utils/domUtils';
 import type { HtmlElementPosition } from './utils/domUtils';
 
-const OPTIONS_LIST_SELECTOR = '.ms-select-all, ul[role=combobox] li[role=option]';
-const OPTIONS_HIGHLIGHT_LIST_SELECTOR = '.ms-select-all.highlighted, ul[role=combobox] li[role=option].highlighted';
+const OPTIONS_LIST_SELECTOR = '.ms-select-all, ul li[data-key]';
+const OPTIONS_HIGHLIGHT_LIST_SELECTOR = '.ms-select-all.highlighted, ul li[data-key].highlighted';
 
 export class MultipleSelectInstance {
   protected _bindEventService: BindingEventService;


### PR DESCRIPTION
- I was a little bit surprised about this but on certain platforms (mainly Salesforce in my case), the `role` attributes might completely stripped out of the final DOM template. So the DOM query I was using for arrow highlight navigation wasn't working at all in Salesforce. So removing `[role]` from the query selector is enough to get it working, however I'll add `li[datakey]` to get it working in Salesforce but still keep it focused to our expected list of elements to query for the arrow navigation to work