### PR TITLE
fix: flip icon vertically when select drop is open

### DIFF
--- a/packages/multiple-select-vanilla/src/MultipleSelectInstance.ts
+++ b/packages/multiple-select-vanilla/src/MultipleSelectInstance.ts
@@ -204,7 +204,7 @@ export class MultipleSelectInstance {
       this.choiceElm.appendChild(createDomElement('div', { className: 'ms-icon ms-icon-close' }));
     }
 
-    this.choiceElm.appendChild(createDomElement('div', { className: 'ms-icon ms-icon-chevron-down' }));
+    this.choiceElm.appendChild(createDomElement('div', { className: 'ms-icon ms-icon-caret' }));
 
     // default position is bottom
     this.dropElm = createDomElement('div', { className: `ms-drop ${this.options.position}`, ariaExpanded: 'false' }, this.parentElm);

--- a/packages/multiple-select-vanilla/src/styles/multiple-select.scss
+++ b/packages/multiple-select-vanilla/src/styles/multiple-select.scss
@@ -8,7 +8,7 @@
 
 // create couple of SVG icons
 @include createSvgClass("ms-icon-close", "M19,6.41L17.59,5L12,10.59L6.41,5L5,6.41L10.59,12L5,17.59L6.41,19L12,13.41L17.59,19L19,17.59L13.41,12L19,6.41Z");
-@include createSvgClass("ms-icon-chevron-down", "M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z");
+@include createSvgClass("ms-icon-caret", "M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z");
 
 .ms-parent, .ms-drop {
   .ms-icon {
@@ -89,8 +89,11 @@
     div.ms-icon-close {
       margin-right: 2px;
     }
-    div.ms-icon-chevron-down {
+    div.ms-icon-caret {
       font-size: var(--ms-chevron-icon-size, $ms-chevron-icon-size);
+      &.open {
+        transform: scaleY(-1);
+      }
     }
   }
 }


### PR DESCRIPTION
- rotate/flip icon vertically when drop is open
- rename chevron-down icon to caret just to make it simpler and keep same name as before