### PR TITLE
fix: when using `showClear`, don't show btn unless having selection

### DIFF
--- a/packages/multiple-select-vanilla/src/MultipleSelectInstance.ts
+++ b/packages/multiple-select-vanilla/src/MultipleSelectInstance.ts
@@ -29,6 +29,7 @@ export class MultipleSelectInstance {
   protected allSelected = false;
   protected fromHtml = false;
   protected choiceElm!: HTMLButtonElement;
+  protected selectClearElm?: HTMLDivElement | null;
   protected closeElm?: HTMLElement | null;
   protected clearSearchIconElm?: HTMLElement | null;
   protected filterText = '';
@@ -202,7 +203,9 @@ export class MultipleSelectInstance {
     this.choiceElm.appendChild(createDomElement('span', { className: 'ms-placeholder', textContent: this.options.placeholder }));
 
     if (this.options.showClear) {
-      this.choiceElm.appendChild(createDomElement('div', { className: 'ms-icon ms-icon-close' }));
+      this.selectClearElm = createDomElement('div', { className: 'ms-icon ms-icon-close' });
+      this.selectClearElm.style.display = 'none'; // don't show unless filled
+      this.choiceElm.appendChild(this.selectClearElm);
     }
 
     this.choiceElm.appendChild(createDomElement('div', { className: 'ms-icon ms-icon-caret' }));
@@ -1295,6 +1298,12 @@ export class MultipleSelectInstance {
       if (html !== null) {
         spanElm?.classList.remove('ms-placeholder');
         this.applyAsTextOrHtmlWhenEnabled(spanElm, html);
+      }
+
+      // when showClear option is enabled, show clear icon only when drop has an actual selection
+      if (this.options.showClear && this.selectClearElm) {
+        const displayState = html ? 'block' : 'none';
+        this.selectClearElm.style.display = displayState;
       }
 
       if (this.options.displayTitle || this.options.addTitle) {

--- a/playwright/e2e/example15.spec.ts
+++ b/playwright/e2e/example15.spec.ts
@@ -46,6 +46,7 @@ test.describe('Example 15 - Dark Mode', () => {
     await expect(parent3Span).toHaveText('6 of 12 selected');
     expect(await page.locator('div[data-test=group] div.ms-icon-caret')).not.toHaveClass(/open/);
 
+    expect(await page.locator('.ms-parent[data-test=data1] .ms-choice .ms-icon-close')).not.toBeVisible();
     await page.locator('div[data-test=data1] .ms-choice').click();
     const li5LabelElms = await page.locator('div[data-test=data1] li:not(.option-divider)');
     const li5DividerElms = await page.locator('div[data-test=data1] li.option-divider');
@@ -56,6 +57,7 @@ test.describe('Example 15 - Dark Mode', () => {
     expect(await page.locator('div[data-test=data1] div.ms-icon-caret')).toHaveClass(/open/);
     await page.getByRole('button', { name: 'Option 2' }).click();
     await expect(parent4Span).toHaveText('Option 2');
+    expect(await page.locator('.ms-parent[data-test=data1] .ms-choice .ms-icon-close')).toBeVisible();
     expect(await page.locator('div[data-test=data1] div.ms-icon-caret')).not.toHaveClass(/open/);
   });
 });

--- a/playwright/e2e/options24.spec.ts
+++ b/playwright/e2e/options24.spec.ts
@@ -4,28 +4,36 @@ test.describe('Options 24 - Show Clear button', () => {
   test('clear button expect input to be cleared', async ({ page }) => {
     await page.goto(']#/options24');
     await page.locator('[data-test=select1].ms-parent').click();
+    expect(await page.locator('.ms-parent[data-test=select1] .ms-choice .ms-icon-close')).toBeVisible();
     await expect(page.locator('[data-test=select1] .ms-choice span')).toHaveText('January');
     await page.locator('[data-test=select1] .ms-choice .ms-icon-close').click();
     await expect(page.locator('[data-test=select1] .ms-choice span')).toHaveText('');
+    expect(await page.locator('.ms-parent[data-test=select1] .ms-choice .ms-icon-close')).not.toBeVisible();
     await page.locator('[data-test=select1].ms-parent').click();
 
     await page.locator('[data-test=select2].ms-parent').click();
     await expect(page.locator('[data-test=select2] .ms-choice span')).toHaveText('Option 1');
+    expect(await page.locator('.ms-parent[data-test=select2] .ms-choice .ms-icon-close')).toBeVisible();
     await page.locator('[data-test=select2] .ms-choice .ms-icon-close').click();
     await expect(page.locator('[data-test=select2] .ms-choice span')).toHaveText('');
+    expect(await page.locator('.ms-parent[data-test=select2] .ms-choice .ms-icon-close')).not.toBeVisible();
     await page.locator('[data-test=select2].ms-parent').click();
 
+    expect(await page.locator('.ms-parent[data-test=select3] .ms-choice .ms-icon-close')).not.toBeVisible();
     await page.locator('[data-test=select3].ms-parent').click();
     await page.getByRole('checkbox', { name: 'February' }).check();
     await page.getByRole('checkbox', { name: 'March' }).check();
     await page.getByRole('checkbox', { name: 'April' }).check();
+    expect(await page.locator('.ms-parent[data-test=select3] .ms-choice .ms-icon-close')).toBeVisible();
     await expect(page.locator('[data-test=select3] .ms-choice span')).toHaveText('February, March, April');
     await page.getByRole('checkbox', { name: 'May' }).check();
     await expect(page.locator('[data-test=select3] .ms-choice span')).toHaveText('4 of 12 selected');
     await page.locator('[data-test=select3].ms-parent').click();
     await page.locator('[data-test=select3] .ms-choice .ms-icon-close').click();
+    expect(await page.locator('.ms-parent[data-test=select3] .ms-choice .ms-icon-close')).not.toBeVisible();
     await expect(page.locator('[data-test=select3] .ms-choice span')).toHaveText('');
 
+    expect(await page.locator('.ms-parent[data-test=select4] .ms-choice .ms-icon-close')).not.toBeVisible();
     await page.locator('[data-test=select4].ms-parent').click();
     await page.getByLabel('Group 2').check();
     await expect(page.locator('[data-test=select4] .ms-choice span')).toHaveText('[Group 2: Option 4, Option 5, Option 6]');

--- a/playwright/e2e/options38.spec.ts
+++ b/playwright/e2e/options38.spec.ts
@@ -93,6 +93,7 @@ test.describe('Options 38 - Dark Mode', () => {
     await page.getByRole('button', { name: 'Toggle Dark Mode' }).click();
 
     // open 5th select drop
+    expect(await page.locator('.ms-parent[data-test=data1] .ms-choice .ms-icon-close')).not.toBeVisible();
     await page.locator('.ms-parent[data-test=data1]').click();
     await expect(await page.locator('.ms-parent[data-test=data1]')).toHaveClass(/ms-dark-mode/);
     await expect(await page.locator('.ms-drop[data-test=data1]')).toHaveClass(/ms-dark-mode/);


### PR DESCRIPTION
![brave_ZaRG3qfmlA](https://github.com/ghiscoding/multiple-select-vanilla/assets/643976/17232bc0-cb19-4a03-9934-9a0a52c981a9)
