### PR TITLE
fix: nav highlight shouldn't follow mouse pos when using nav arrows

### DIFF
--- a/packages/multiple-select-vanilla/src/MultipleSelectInstance.ts
+++ b/packages/multiple-select-vanilla/src/MultipleSelectInstance.ts
@@ -40,6 +40,7 @@ export class MultipleSelectInstance {
   protected okButtonElm?: HTMLButtonElement;
   protected filterParentElm?: HTMLDivElement | null;
   protected lastFocusedItemKey = '';
+  protected lastMouseOverPosition = '';
   protected ulElm?: HTMLUListElement | null;
   protected parentElm!: HTMLDivElement;
   protected labelElm?: HTMLLabelElement | null;
@@ -1002,7 +1003,8 @@ export class MultipleSelectInstance {
         'mouseover',
         ((e: MouseEvent & { target: HTMLDivElement | HTMLLIElement }) => {
           const liElm = (e.target.closest('.ms-select-all') || e.target.closest('li')) as HTMLLIElement;
-          if (this.dropElm.contains(liElm) && this.scrolledByMouse) {
+
+          if (this.dropElm.contains(liElm) && this.lastMouseOverPosition !== `${e.clientX}:${e.clientY}`) {
             const optionElms = this.dropElm?.querySelectorAll<HTMLLIElement>(OPTIONS_LIST_SELECTOR) || [];
             const newIdx = Array.from(optionElms).findIndex(el => el.dataset.key === liElm.dataset.key);
             if (this._currentHighlightIndex !== newIdx && !liElm.classList.contains('disabled')) {
@@ -1011,6 +1013,7 @@ export class MultipleSelectInstance {
               this.changeCurrentOptionHighlight(liElm);
             }
           }
+          this.lastMouseOverPosition = `${e.clientX}:${e.clientY}`;
         }) as EventListener,
         undefined,
         'hover-highlight',


### PR DESCRIPTION
- when using arrow keys to change navigation highlight, it triggers couple of cascading events (1. onScroll event => 2. onMouseOver event). The onMouseOver has the side effect of changing the highlight to current mouse position, so that indirectly affected the arrow navigation since instead of staying at the bottom end, it was always resetting to mouse position (as shown in animated gif below). To counter this problem, we can save the last know mouse position and compare it inside the mouseover, if the position is exactly the same then we know that we're not using the mouse but we are actually using arrow navigation (so we skip mouseover exec)

#### below is the mouseover problem demoed
this PR fixes the issue observed below (when the mouse is over the options list)

![brave_1ezRIpK06H](https://github.com/ghiscoding/multiple-select-vanilla/assets/643976/90d613cc-a8a7-47b5-b1f5-803b940e3e22)
