### PR TITLE
fix: add missing div selector in previous CSS class name typo

### DIFF
--- a/packages/multiple-select-vanilla/src/styles/multiple-select.scss
+++ b/packages/multiple-select-vanilla/src/styles/multiple-select.scss
@@ -139,10 +139,10 @@
         color: var(--ms-placeholder-color, v.$ms-placeholder-color);
       }
     }
-    .ms-icon-close {
+    div.ms-icon-close {
       margin-right: 2px;
     }
-    .ms-icon-caret {
+    div.ms-icon-caret {
       height: var(--ms-chevron-icon-size, v.$ms-chevron-icon-size);
       width: var(--ms-chevron-icon-size, v.$ms-chevron-icon-size);
       &.open {


### PR DESCRIPTION
in a previous commit b0e5d4d that fixed a typo introduced in PR #308, it actually only fixed the typo but in reality the typo was caused by a search & replace text and the `div.ms-icon-x` ended up dropping the `div.`, so we should probably add the div selector back