### PR TITLE
chore: upgrade to Vite 6 and remove modern compiler

### DIFF
--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -28,6 +28,6 @@
   "devDependencies": {
     "sass": "^1.80.4",
     "typescript": "5.6.3",
-    "vite": "^6.0.0-beta.5"
+    "vite": "^6.0.0"
   }
 }

--- a/packages/demo/vite.config.mts
+++ b/packages/demo/vite.config.mts
@@ -11,11 +11,4 @@ export default defineConfig({
   optimizeDeps: {
     exclude: ['multiple-select-vanilla'],
   },
-  css: {
-    preprocessorOptions: {
-      scss: {
-        api: 'modern-compiler',
-      },
-    },
-  },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,8 +70,8 @@ importers:
         specifier: 5.6.3
         version: 5.6.3
       vite:
-        specifier: ^6.0.0-beta.5
-        version: 6.0.0-beta.9(@types/node@22.9.0)(sass@1.80.4)
+        specifier: ^6.0.0
+        version: 6.0.0(@types/node@22.9.0)(sass@1.80.4)
 
   packages/multiple-select-vanilla:
     dependencies:
@@ -1928,6 +1928,9 @@ packages:
   picocolors@1.1.0:
     resolution: {integrity: sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw==}
 
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
   picomatch@2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
@@ -2164,6 +2167,10 @@ packages:
 
   postcss@8.4.47:
     resolution: {integrity: sha512-56rxCq7G/XfB4EkXq9Egn5GCqugWvDFjafDOThIdMBsI15iqPqR5r15TfSr1YPYeEI19YeaXMCbY6u88Y76GLQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  postcss@8.4.49:
+    resolution: {integrity: sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==}
     engines: {node: ^10 || ^12 || >=14}
 
   pretty-hrtime@1.0.3:
@@ -2549,12 +2556,12 @@ packages:
     resolution: {integrity: sha512-YuKoXDAhBYxY7SfOKxHBDoSyENFeW5VvIIQp2TGQuit8gpK6MnWaQelBKxso72DoxTZfZdcP3W90LqpSkgPzLQ==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
-  vite@6.0.0-beta.9:
-    resolution: {integrity: sha512-gMaa1/cnKw4xCv1QmPcBInF8D1I17a0/+kUDWuPLGm0ZuupFW2YKUU91DQFc4WwgvvEKFd+kNHin9+qlX0SeqQ==}
-    engines: {node: ^18.0.0 || >=20.0.0}
+  vite@6.0.0:
+    resolution: {integrity: sha512-Q2+5yQV79EdnpbNxjD3/QHVMCBaQ3Kpd4/uL51UGuh38bIIM+s4o3FqyCzRvTRwFb+cWIUeZvaWwS9y2LD2qeQ==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
-      '@types/node': ^18.0.0 || >=20.0.0
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
       jiti: '>=1.21.0'
       less: '*'
       lightningcss: ^1.21.0
@@ -4640,6 +4647,8 @@ snapshots:
 
   picocolors@1.1.0: {}
 
+  picocolors@1.1.1: {}
+
   picomatch@2.3.1: {}
 
   picomatch@4.0.2: {}
@@ -4855,6 +4864,12 @@ snapshots:
     dependencies:
       nanoid: 3.3.7
       picocolors: 1.1.0
+      source-map-js: 1.2.1
+
+  postcss@8.4.49:
+    dependencies:
+      nanoid: 3.3.7
+      picocolors: 1.1.1
       source-map-js: 1.2.1
 
   pretty-hrtime@1.0.3: {}
@@ -5233,13 +5248,14 @@ snapshots:
     dependencies:
       builtins: 5.0.1
 
-  vite@6.0.0-beta.9(@types/node@22.9.0)(sass@1.80.4):
+  vite@6.0.0(@types/node@22.9.0)(sass@1.80.4):
     dependencies:
       esbuild: 0.24.0
-      postcss: 8.4.47
+      postcss: 8.4.49
       rollup: 4.24.0
     optionalDependencies:
       '@types/node': 22.9.0
+      fsevents: 2.3.3
       sass: 1.80.4
 
   walk-up-path@3.0.1: {}


### PR DESCRIPTION
- Vite 6 made SASS modern-compiler the default so we can remove unnecessary option