### PR TITLE
fix: when `closeOnTab` w/OK button, it should take 2 Tabs to close

### DIFF
--- a/packages/multiple-select-vanilla/src/models/multipleSelectOption.interface.ts
+++ b/packages/multiple-select-vanilla/src/models/multipleSelectOption.interface.ts
@@ -73,7 +73,11 @@ export interface MultipleSelectOption extends MultipleSelectLocale {
   /** The class prefix of select. */
   classPrefix?: string;
 
-  /** Should we close the drop when Tab key is pressed. */
+  /**
+   * Should we close the drop when Tab key is pressed.
+   * Side note: when using a multiple select with the "OK" button enabled,
+   * it will require 2 Tabs (1. focus on "OK", 2. close drop)
+   */
   closeOnTab?: boolean;
 
   /** HTML container to use for the drop menu, e.g. 'body' */

--- a/playwright/e2e/options25.spec.ts
+++ b/playwright/e2e/options25.spec.ts
@@ -28,7 +28,7 @@ test.describe('Options 25 - Show OK Button', () => {
   });
 
   test('Tab and Shift+Tab to switch from OK button to List', async ({ page }) => {
-    // 1st select
+    // 1st Select
     await page.goto('#/options25');
     await page.locator('[data-test=select1].ms-parent').click();
     await page.getByRole('option', { name: 'April' }).click();
@@ -39,14 +39,26 @@ test.describe('Options 25 - Show OK Button', () => {
     await expect(page.locator('div[data-test=select1] .ms-ok-button')).toBeFocused();
     await page.keyboard.press('Shift+Tab');
     await expect(page.locator('div[data-test=select1] .ms-select-all input')).toBeFocused();
-    await page.keyboard.press('Shift+Tab');
+    await page.keyboard.press('Tab');
+    await page.keyboard.press('Enter');
     await expect(page.locator('div[data-test=select1] .ms-drop')).toBeHidden();
 
-    // last select Shift+Tab will close drop
+    // 3rd Select
+    await page.locator('[data-test=select3].ms-parent').click();
+    await page.locator('div:nth-child(2) > label > .icon-checkbox-container').click();
+    await page.keyboard.press('Tab');
+    await expect(page.locator('div[data-test=select3] .ms-ok-button')).toBeFocused();
+    await page.keyboard.press('Shift+Tab');
+    await expect(page.locator('div[data-test=select3] .ms-search input')).toBeFocused();
+    await page.keyboard.press('Tab');
+    await page.keyboard.press('Enter');
+    await expect(page.locator('div[data-test=select3] .ms-drop')).toBeHidden();
+
+    // 4th Select Enter key will close drop
     await page.locator('[data-test=select4].ms-parent').click();
     await page.keyboard.press('ArrowDown');
     await page.keyboard.press('ArrowDown');
-    await page.keyboard.press('Shift+Tab');
+    await page.keyboard.press('Enter');
     await expect(page.locator('div[data-test=select4] .ms-drop')).toBeHidden();
   });
 });

--- a/playwright/e2e/options34.spec.ts
+++ b/playwright/e2e/options34.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 
 test.describe('Options 34 - Show Search Clear button', () => {
   test('filtering on all type of select & clear search input', async ({ page }) => {

--- a/playwright/e2e/options43.spec.ts
+++ b/playwright/e2e/options43.spec.ts
@@ -37,8 +37,10 @@ test.describe('Options 43 - Close on Tab', () => {
     // 5th Select
     await page.locator('div[data-test=data1] .ms-choice').click();
     await expect(page.locator('div[data-test=data1] .ms-drop')).toBeVisible();
-    await page.keyboard.press('Tab');
+    await page.keyboard.press('Tab'); // 1st Tab will focus on "OK" button
+    await expect(page.locator('div[data-test=data1] .ms-drop')).toBeVisible();
+    await expect(page.locator('div[data-test=data1] .ms-ok-button')).toBeFocused();
+    await page.keyboard.press('Tab'); // 2nd Tab will close the drop
     await expect(page.locator('div[data-test=data1] .ms-drop')).not.toBeVisible();
-    // });
   });
 });


### PR DESCRIPTION
- when multiple select is enabled and "OK" button is shown, it should take 2x Tab keys pressed to close the drop
  1. focus on "OK" button
  2. close drop
- fix some more issues after testing it more thoroughly in Slickgrid-Universal, there were some event conflicts since previous code had 2 listeners on the same drop element