### PR TITLE
fix: `event.composePath()` throws in Salesforce environment

### DIFF
--- a/packages/multiple-select-vanilla/src/MultipleSelectInstance.ts
+++ b/packages/multiple-select-vanilla/src/MultipleSelectInstance.ts
@@ -554,10 +554,11 @@ export class MultipleSelectInstance {
   }
 
   protected getEventTarget(e: Event & { target: HTMLElement }): HTMLElement {
-    if (e.composedPath) {
-      return e.composedPath()[0] as HTMLElement;
+    try {
+      return (e.composedPath?.()[0] || (e as any).path?.[0] || e.target) as HTMLElement;
+    } catch {
+      return e.target as HTMLElement;
     }
-    return e.target as HTMLElement;
   }
 
   protected getListRows(): HtmlStruct[] {


### PR DESCRIPTION
- calling `event.composePath()` in a Salesforce environment with LWC and the locker API throws with an error: "Illegal Invocation" or "function does not exists"