### PR TITLE
fix: any min/max width options should be applied to drop CSS style

### DIFF
--- a/packages/multiple-select-vanilla/src/MultipleSelectInstance.ts
+++ b/packages/multiple-select-vanilla/src/MultipleSelectInstance.ts
@@ -241,8 +241,15 @@ export class MultipleSelectInstance {
 
     this.closeElm = this.choiceElm.querySelector('.ms-icon-close');
 
-    if (this.options.dropWidth) {
-      this.dropElm.style.width = typeof this.options.dropWidth === 'string' ? this.options.dropWidth : `${this.options.dropWidth}px`;
+    // any of the drop width options provided should apply them to the associated drop style
+    const styleOptions = ['minWidth', 'maxWidth', 'width', 'dropWidth'] as unknown as Array<keyof MultipleSelectOption>;
+    for (const stlOption of styleOptions) {
+      if (this.options[stlOption]) {
+        // options.dropWidth needs to be aliased to style.width, anything else are the same prop/style name
+        const styleProp = stlOption === 'dropWidth' ? 'width' : (stlOption as 'minWidth' | 'maxWidth' | 'width');
+        this.dropElm.style[styleProp] =
+          typeof this.options[stlOption] === 'string' ? this.options[stlOption] : `${this.options[stlOption]}px`;
+      }
     }
 
     insertAfter(this.elm, this.parentElm);


### PR DESCRIPTION
Any of these options `minWidth, maxWidth, width, dropWidth` should assign the option to the CSS style on the drop element. Note that the `dropWidth` is of course a custom option to assign as the drop `width` CSS style