### PR TITLE
chore(deps): use `remove-glob` instead of `rimraf`

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "are-types-wrong": "pnpm -r --stream --filter=\"{packages/multiple-select-vanilla/**}\" are-types-wrong",
-    "clean": "rimraf --glob **/dist **/tsconfig.tsbuildinfo",
+    "clean": "remove --glob **/dist --glob **/tsconfig.tsbuildinfo",
     "prebuild": "pnpm clean && pnpm biome:lint:write && pnpm biome:format:write",
     "build": "pnpm -r --stream build",
     "build:demo": "pnpm -r --stream --filter=\"{packages/demo/**}\" build",
@@ -49,7 +49,7 @@
     "preroll-new-release": "echo Please update getting-started lib version before pushing a release. ⚠️",
     "roll-new-release": "pnpm build && pnpm new-version && pnpm new-publish",
     "serve:demo": "pnpm -r --stream --filter=\"{packages/demo/**}\" dev",
-    "pretest:e2e": "rimraf playwright-report",
+    "pretest:e2e": "remove playwright-report",
     "test:e2e": "playwright test --config playwright/playwright.config.ts",
     "test:e2e:debug": "playwright test --config playwright/playwright.config.ts --ui --debug",
     "test:e2e:ui": "playwright test --config playwright/playwright.config.ts --ui",
@@ -70,7 +70,7 @@
     "conventional-changelog-conventionalcommits": "^9.1.0",
     "cross-env": "catalog:",
     "npm-run-all2": "^8.0.4",
-    "rimraf": "^6.0.1",
+    "remove-glob": "^0.3.4",
     "typescript": "catalog:"
   },
   "packageManager": "pnpm@10.10.0"

--- a/packages/multiple-select-vanilla/package.json
+++ b/packages/multiple-select-vanilla/package.json
@@ -50,7 +50,7 @@
   },
   "scripts": {
     "are-types-wrong": "pnpx @arethetypeswrong/cli --pack .",
-    "clean": "rimraf dist",
+    "clean": "remove dist",
     "build": "pnpm build:all && pnpm build:types:prod",
     "postbuild": "pnpm sass:build && pnpm sass:copy",
     "dev:init": "pnpm sass:build && pnpm sass:copy && pnpm build:all && pnpm build:types:prod",
@@ -76,6 +76,7 @@
     "native-copyfiles": "^1.3.4",
     "postcss": "^8.5.6",
     "postcss-cli": "^11.0.1",
+    "remove-glob": "^0.3.3",
     "sass": "catalog:",
     "tinyglobby": "^0.2.14",
     "typescript": "catalog:"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,9 +47,9 @@ importers:
       npm-run-all2:
         specifier: ^8.0.4
         version: 8.0.4
-      rimraf:
-        specifier: ^6.0.1
-        version: 6.0.1
+      remove-glob:
+        specifier: ^0.3.4
+        version: 0.3.4
       typescript:
         specifier: 'catalog:'
         version: 5.8.3
@@ -109,6 +109,9 @@ importers:
       postcss-cli:
         specifier: ^11.0.1
         version: 11.0.1(postcss@8.5.6)
+      remove-glob:
+        specifier: ^0.3.3
+        version: 0.3.3
       sass:
         specifier: 'catalog:'
         version: 1.89.2
@@ -1325,11 +1328,6 @@ packages:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
     hasBin: true
 
-  glob@11.0.2:
-    resolution: {integrity: sha512-YT7U7Vye+t5fZ/QMkBFrTJ7ZQxInIUjwyAjVj84CYXqgBdv30MFUPGnBR6sQaVq6Is15wYJUsnzTuWaGRBhBAQ==}
-    engines: {node: 20 || >=22}
-    hasBin: true
-
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
@@ -1459,10 +1457,6 @@ packages:
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
-  jackspeak@4.1.0:
-    resolution: {integrity: sha512-9DDdhb5j6cpeitCbvLO7n7J4IxnbM6hoF6O1g4HQ5TfhvvKN8ywDM7668ZhMHRqVmxqhps/F6syWK2KcPxYlkw==}
-    engines: {node: 20 || >=22}
-
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -1527,10 +1521,6 @@ packages:
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
-  lru-cache@11.1.0:
-    resolution: {integrity: sha512-QIXZUBJUx+2zHUdQujWejBkcD9+cs94tLn0+YL8UrCh+D5sCXZ4c7LaEH48pNwRY3MLDgqUFyhlCyjJPf1WP0A==}
-    engines: {node: 20 || >=22}
-
   make-fetch-happen@14.0.3:
     resolution: {integrity: sha512-QMjGbFTP0blj97EeidG5hk/QhKQ3T4ICckQGLgz38QF7Vgbk6e6FTARN8KhKxyBbWn8R0HU+bnw8aSoFPD4qtQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
@@ -1552,10 +1542,6 @@ packages:
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
-
-  minimatch@10.0.1:
-    resolution: {integrity: sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==}
-    engines: {node: 20 || >=22}
 
   minimatch@9.0.5:
     resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
@@ -1792,10 +1778,6 @@ packages:
   path-scurry@1.11.1:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
-
-  path-scurry@2.0.0:
-    resolution: {integrity: sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==}
-    engines: {node: 20 || >=22}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -2091,6 +2073,16 @@ packages:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
 
+  remove-glob@0.3.3:
+    resolution: {integrity: sha512-4n3sA7TESAjORoqm2Mzjsj7o4pOgpDBbhMCN6Zf0jeReDYB868zqbQgILCgvUmr/dEnoea1DwAUNChPVCGmL2g==}
+    engines: {node: ^20.0.0 || >=22.0.0}
+    hasBin: true
+
+  remove-glob@0.3.4:
+    resolution: {integrity: sha512-3ArOVIthanoWsUbWfhlLXq3qHzaoF0fsjHnycpGVURZjf2Vww3TTPFo3wQXGqouqpuRKVWkuoRkf7BcSL6EPJA==}
+    engines: {node: ^20.0.0 || >=22.0.0}
+    hasBin: true
+
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
@@ -2106,11 +2098,6 @@ packages:
   retry@0.12.0:
     resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
     engines: {node: '>= 4'}
-
-  rimraf@6.0.1:
-    resolution: {integrity: sha512-9dkvaxAsk/xNXSJzMgFqqMCuFgt2+KsOFek3TMLfo8NCPfWpBmqwyNn5Y+NX56QUYfCtsyhF3ayiboEoUmJk/A==}
-    engines: {node: 20 || >=22}
-    hasBin: true
 
   rollup@4.40.1:
     resolution: {integrity: sha512-C5VvvgCCyfyotVITIAv+4efVytl5F7wt+/I2i9q9GZcEXW9BP52YYOXC58igUi+LFZVHukErIIqQSWwv/M3WRw==}
@@ -3767,15 +3754,6 @@ snapshots:
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
 
-  glob@11.0.2:
-    dependencies:
-      foreground-child: 3.3.1
-      jackspeak: 4.1.0
-      minimatch: 10.0.1
-      minipass: 7.1.2
-      package-json-from-dist: 1.0.1
-      path-scurry: 2.0.0
-
   graceful-fs@4.2.11: {}
 
   grammex@3.1.10: {}
@@ -3888,10 +3866,6 @@ snapshots:
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
 
-  jackspeak@4.1.0:
-    dependencies:
-      '@isaacs/cliui': 8.0.2
-
   js-tokens@4.0.0: {}
 
   jsbn@1.1.0: {}
@@ -3950,8 +3924,6 @@ snapshots:
 
   lru-cache@10.4.3: {}
 
-  lru-cache@11.1.0: {}
-
   make-fetch-happen@14.0.3:
     dependencies:
       '@npmcli/agent': 3.0.0
@@ -3981,10 +3953,6 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.1
     optional: true
-
-  minimatch@10.0.1:
-    dependencies:
-      brace-expansion: 2.0.1
 
   minimatch@9.0.5:
     dependencies:
@@ -4241,11 +4209,6 @@ snapshots:
   path-scurry@1.11.1:
     dependencies:
       lru-cache: 10.4.3
-      minipass: 7.1.2
-
-  path-scurry@2.0.0:
-    dependencies:
-      lru-cache: 11.1.0
       minipass: 7.1.2
 
   picocolors@1.1.1: {}
@@ -4513,6 +4476,16 @@ snapshots:
 
   readdirp@4.1.2: {}
 
+  remove-glob@0.3.3:
+    dependencies:
+      cli-nano: 1.2.1
+      tinyglobby: 0.2.14
+
+  remove-glob@0.3.4:
+    dependencies:
+      cli-nano: 1.2.1
+      tinyglobby: 0.2.14
+
   require-directory@2.1.1: {}
 
   resolve-cwd@3.0.0:
@@ -4522,11 +4495,6 @@ snapshots:
   resolve-from@5.0.0: {}
 
   retry@0.12.0: {}
-
-  rimraf@6.0.1:
-    dependencies:
-      glob: 11.0.2
-      package-json-from-dist: 1.0.1
 
   rollup@4.40.1:
     dependencies:


### PR DESCRIPTION
- I created my own [remove-glob](https://www.npmjs.com/package/remove-glob) which is 14x smaller than `rimraf` while still providing glob patterns (`premove` is a much better alternative when glob aren't necessary though). 