### PR TITLE
fix: make .icon-checkbox-container's border-radius variable

### DIFF
--- a/packages/multiple-select-vanilla/src/styles/_variables.scss
+++ b/packages/multiple-select-vanilla/src/styles/_variables.scss
@@ -17,6 +17,7 @@ $ms-checkbox-hover-color: color.adjust($ms-primary-color, $lightness: -3%) !defa
 $ms-checkbox-icon-container-border: 1px solid #d0d0d0 !default;
 $ms-checkbox-icon-container-height: 1.05rem !default;
 $ms-checkbox-icon-container-width: 1.05rem !default;
+$ms-checkbox-icon-container-border-radius: 0.125rem !default;
 $ms-choice-border: 1px solid #d0d0d0 !default;
 $ms-choice-border-radius: 4px !default;
 $ms-choice-bgcolor: #fff !default;

--- a/packages/multiple-select-vanilla/src/styles/multiple-select.scss
+++ b/packages/multiple-select-vanilla/src/styles/multiple-select.scss
@@ -55,7 +55,7 @@
       height: var(--ms-checkbox-icon-container-height, v.$ms-checkbox-icon-container-height);
       width: var(--ms-checkbox-icon-container-width, v.$ms-checkbox-icon-container-width);
       border: var(--ms-checkbox-icon-container-border, v.$ms-checkbox-icon-container-border);
-      border-radius: 0.125rem;
+      border-radius: var(--ms-checkbox-icon-container-border-radius, v.$ms-checkbox-icon-container-border-radius);
      
       div {
         font-size: 14px;


### PR DESCRIPTION
I just flew in from trying to style the `.icon-checkbox-container`'s `border-radius` property and _boy_ are my arms tired.
