### PR TITLE
fix: consider `virtualScroll` option to really disable Virtual Scroll

### DIFF
--- a/packages/multiple-select-vanilla/src/MultipleSelectInstance.ts
+++ b/packages/multiple-select-vanilla/src/MultipleSelectInstance.ts
@@ -492,7 +492,7 @@ export class MultipleSelectInstance {
       offset = -1;
     }
 
-    if (rows.length > Constants.BLOCK_ROWS * Constants.CLUSTER_BLOCKS) {
+    if (this.options.virtualScroll && rows.length > Constants.BLOCK_ROWS * Constants.CLUSTER_BLOCKS) {
       const dropVisible = this.dropElm && this.dropElm?.style.display !== 'none';
       if (!dropVisible && this.dropElm) {
         this.dropElm.style.left = '-10000';


### PR DESCRIPTION
Hey! Thanks for a nice library!
Documentation states that it's possible to disable virtual scroll with `virtualScroll: false` in MS instance.
When I tried to use `virtualScroll: false` to mitigate issue with virtual scroll, it didn't change multiple select behaviour. Last version it worked was [v3.0.0](https://github.com/ghiscoding/multiple-select-vanilla/tree/v3.0.0)
I've re-added check for `virtualScroll` option that was removed here: https://github.com/ghiscoding/multiple-select-vanilla/compare/v3.0.0...v3.1.0#diff-98fa1c735f911481424d25b4bd48d504abb02519365960551d3dc2e0a08631ecR463