### PR TITLE
fix: `close()` fn and `options.onClose()` should only be called w/open drop

### DIFF
--- a/packages/multiple-select-vanilla/src/MultipleSelectInstance.ts
+++ b/packages/multiple-select-vanilla/src/MultipleSelectInstance.ts
@@ -29,6 +29,7 @@ const OPTIONS_HIGHLIGHT_LIST_SELECTOR = '.ms-select-all.highlighted, ul li[data-
 
 export class MultipleSelectInstance {
   protected _bindEventService: BindingEventService;
+  protected _isOpen = false;
   protected isAllSelected = false;
   protected isPartiallyAllSelected = false;
   protected fromHtml = false;
@@ -275,11 +276,9 @@ export class MultipleSelectInstance {
             return;
           }
 
-          if (
-            (this.getEventTarget(e) === this.dropElm ||
-              (findParent(this.getEventTarget(e), '.ms-drop') !== this.dropElm && this.getEventTarget(e) !== this.elm)) &&
-            this.options.isOpen
-          ) {
+          const eventTarget = this.getEventTarget(e);
+          const fpDropElm = findParent(this.getEventTarget(e), '.ms-drop');
+          if (this._isOpen && (eventTarget === this.dropElm || (fpDropElm !== this.dropElm && eventTarget !== this.elm))) {
             this.close('body.click');
           }
         }) as EventListener,
@@ -1306,6 +1305,7 @@ export class MultipleSelectInstance {
       this.highlightCurrentOption();
     }
 
+    this._isOpen = true;
     this.options.onOpen();
   }
 
@@ -1460,6 +1460,7 @@ export class MultipleSelectInstance {
   }
 
   close(reason?: CloseReason) {
+    this._isOpen = false;
     this.options.isOpen = false;
     this.parentElm.classList.remove('ms-parent-open');
     this.choiceElm?.querySelector('div.ms-icon-caret')?.classList.remove('open');


### PR DESCRIPTION
when instantiating ms-select with option `{ isOpen: true }`, we delay the opening of the drop by a CPU cycle. However the issue is that the `initContainer()` has a `click` event listener on the `document.body` and when `{ isOpen: true }` is provided, it triggers the click event (not really sure why but it doesn't really matter) and the bug is that we should allow the `close()` and `options.onClose()` to be called **only** if the drop is really open (and it's not opened until the CPU cycle delay, so we need another internal `_isOpen` variable to reference and with that in place the close isn't being called anymore when we first open originally open the drop)

This fixes an issue identified in Slickgrid-Universal were it was calling the `options.onClose()` when creating and opening the drop... so with the fix in place, it no longer calls the onClose() on the original drop opening. 